### PR TITLE
add test and predict

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -78,6 +78,7 @@ EVALUATION:
     function: "topk"
     topk: (1,5)
 
+model_name: "example"
 log_interval: 20 #Optional, the interal of logger
 epochs: 2 #Mandatory, total epoch
 log_level: "DEBUG" #Optional, the logger level.

--- a/configs/recognition/tsm/tsm.yaml
+++ b/configs/recognition/tsm/tsm.yaml
@@ -24,6 +24,12 @@ DATASET: #DATASET field
         data_prefix: "" #Mandatory, valid data root path
         file_path: "data/ucf101/ucf101_val_split_1_rawframes.txt" #Mandatory, valid data index file path
         suffix: 'img_{:05}.jpg'
+    test:
+        format: "FrameDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
+        data_prefix: "" #Mandatory, valid data root path
+        file_path: "data/ucf101/ucf101_val_split_1_rawframes.txt" #Mandatory, valid data index file path
+        suffix: 'img_{:05}.jpg'
+
 
 PIPELINE: #PIPELINE field
     train: #Mandotary, indicate the pipeline to deal with the training data, associate to the 'paddlevideo/loader/pipelines/'
@@ -66,6 +72,26 @@ PIPELINE: #PIPELINE field
                 mean: [0.485, 0.456, 0.406]
                 std: [0.229, 0.224, 0.225]
 
+    test:
+        decode:
+            name: "FrameDecoder"
+        sample:
+            name: "Sampler"
+            valid_mode: True
+            num_seg: 8
+            seg_len: 1
+            valid_mode: True
+        transform:
+            - Scale:
+                short_size: 256
+            - CenterCrop:
+                target_size: 224
+            - Image2Array:
+            - Normalization:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.229, 0.224, 0.225]
+
+
 OPTIMIZER: #OPTIMIZER field
     name: 'Momentum' #Mandatory, the type of optimizer, associate to the 'paddlevideo/solver/'
     momentum: 0.9 
@@ -82,6 +108,7 @@ EVALUATION:
     function: "topk"
     topk: (1,5)
 
+model_name: "TSM"
 log_interval: 20 #Optional, the interal of logger, default:10
 epochs: 80 #Mandatory, total epoch
 log_level: "DEBUG" #Optional, the logger level. default: "INFO"

--- a/main.py
+++ b/main.py
@@ -18,39 +18,31 @@ from paddlevideo.loader.builder import build_dataloader, build_dataset
 from paddlevideo.modeling.builder import build_model
 from paddlevideo.tasks import train_model
 from paddlevideo.utils import get_dist_info
-from paddlevideo.utils import setup_logger
+
 
 def parse_args():
     parser = argparse.ArgumentParser("PaddleVideo train script")
-    parser.add_argument(
-        '-c',
-        '--config',
-        type=str,
-        default='configs/example.yaml',
-        help='config file path')
-    parser.add_argument(
-        '-o',
-        '--override',
-        action='append',
-        default=[],
-        help='config options to be overridden')
+    parser.add_argument('-c',
+                        '--config',
+                        type=str,
+                        default='configs/example.yaml',
+                        help='config file path')
+    parser.add_argument('-o',
+                        '--override',
+                        action='append',
+                        default=[],
+                        help='config options to be overridden')
     parser.add_argument(
         '--validate',
         action='store_true',
         help='whether to evaluate the checkpoint during training')
-    parser.add_argument(
-        '--seed',
-        type=int,
-        default=None,
-        help='random seed')
+    parser.add_argument('--seed', type=int, default=None, help='random seed')
 
     args = parser.parse_args()
     return args
 
 
 def main():
-
-    logger = setup_logger("./", name="paddlevideo", level="INFO")
 
     args = parse_args()
 
@@ -74,11 +66,7 @@ def main():
     if args.validate:
         dataset.append(build_dataset((cfg.DATASET.valid, cfg.PIPELINE.valid)))
 
-    train_model(model,
-		dataset, 
-		cfg,
-                parallel=parallel,
-                validate=args.validate)
+    train_model(model, dataset, cfg, parallel=parallel, validate=args.validate)
 
 
 if __name__ == '__main__':

--- a/paddlevideo/modeling/backbones/resnet_tsm.py
+++ b/paddlevideo/modeling/backbones/resnet_tsm.py
@@ -294,10 +294,15 @@ class ResNetTSM(nn.Layer):
         """Define how the backbone is going to run.
         
         """
-        #NOTE: Already merge axis 0(batches) and axis 1(channels) before extracting feature phase, 
+        #NOTE: (deprecated design) Already merge axis 0(batches) and axis 1(clips) before extracting feature phase, 
         # please refer to paddlevideo/modeling/framework/recognizers/recognizer2d.py#L27
         #y = paddle.reshape(
         #    inputs, [-1, inputs.shape[2], inputs.shape[3], inputs.shape[4]])
+
+        #NOTE: As paddlepaddle to_static method need a "pure" model to trim. It means from 
+        #  1. the phase of generating data[images, label] from dataloader 
+        #     to 
+        #  2. last layer of a model, always is FC layer
 
         y = self.conv(inputs)
         y = self.pool2D_max(y)

--- a/paddlevideo/modeling/framework/recognizers/base.py
+++ b/paddlevideo/modeling/framework/recognizers/base.py
@@ -51,24 +51,34 @@ class BaseRecognizer(nn.Layer):
         return feature
 
 
+    def average_clip(self, cls_score, num_segs=1):
+        batch_size = cls_score.shape[0]
+        cls_score = paddle.reshape(batch_size // num_segs, num_segs, -1)
+        softmax_out = F.softmax(cls_score)
+        return softmax_out
+
+
     @abstractmethod
-    def forward_train(self, imgs, labels, **kwargs):
+    def forward_train(self, imgs, labels, reduce_sum, **kwargs):
         pass
 
     @abstractmethod
-    def forward_valid(self, imgs):
+    def forward_test(self, imgs, labels,reduce_sum, **kwargs):
         pass
 
 
-    def forward(self, imgs, labels=None, return_loss=True, reduce_sum=False, **kwargs):
+    def forward(self, imgs, **kwargs):
         """Define how the model is going to run, from input to output.
         """
-        if return_loss:
-            if labels is None:
-                raise ValueError("Label should not be None.")
-            return self.forward_train(imgs, labels, reduce_sum=reduce_sum, **kwargs)
-        else:
-            return self.forward_valid(imgs)
+        batches = imgs.shape[0]
+        num_segs = imgs.shape[1]
+        imgs = paddle.reshape(imgs, [-1]+list(imgs.shape[2:]))
+
+        feature = self.extract_feature(imgs)
+        cls_score = self.head(feature, num_segs)
+
+        return cls_score
+
 
     def train_step(self, data_batch, **kwargs):
         """Training step.
@@ -77,7 +87,8 @@ class BaseRecognizer(nn.Layer):
         labels = data_batch[1]
 
         # call forward
-        loss_metrics = self(imgs, labels, return_loss=True)
+        loss_metrics = self.forward_train(imgs, labels, reduce_sum=False, **kwargs)
+
         return loss_metrics
 
     def val_step(self, data_batch, **kwargs):
@@ -87,5 +98,13 @@ class BaseRecognizer(nn.Layer):
         labels = data_batch[1]
 
         # call forward
-        loss_metrics = self(imgs, labels, reducesum=True, return_loss=True)
+        loss_metrics = self.forward_train(imgs, labels, reduce_sum=True, **kwargs)
         return loss_metrics
+
+    def test_step(self, data_batch, **kwargs):
+        imgs = data_batch[0]
+        labels = data_batch[1]
+
+        metrics = self.forward_test(imgs, labels, reduce_sum=True, **kwargs)
+        return metrics
+        

--- a/paddlevideo/modeling/framework/recognizers/recognizer2d.py
+++ b/paddlevideo/modeling/framework/recognizers/recognizer2d.py
@@ -25,24 +25,23 @@ class Recognizer2D(BaseRecognizer):
     def forward_train(self, imgs, labels, reduce_sum, **kwargs):
         """Define how the model is going to train, from input to output.
         """
-        # As the num_segs is an attribute of dataset phase, and didn't pass to build_head phase, should obtain it from imgs(paddle.Tensor) now, then call self.head method.
-        
-        batches = imgs.shape[0]
-        imgs = paddle.reshape(imgs, [-1]+imgs.shape[2:])
-        num_segs = imgs.shape[0] // batches
-        feature = self.extract_feature(imgs)
-        cls_score = self.head(feature, num_segs)
+        #NOTE: As the num_segs is an attribute of dataset phase, and didn't pass to build_head phase, should obtain it from imgs(paddle.Tensor) now, then call self.head method.
+
         #labels = labels.squeeze()
         #XXX: unsqueeze label to [label] ?
+        
+        cls_score = self(imgs)
         loss_metrics = self.head.loss(cls_score, labels, reduce_sum, **kwargs)
         return loss_metrics
 
-    def forward_valid(self, imgs):
-        """Define how the model is going to valid, from input to output."""
-        #XXX add testing code.
-        imgs = paddle.reshape(imgs, [-1]+imgs.shape[2:])
-        num_segs = imgs.shape[0] // batches
-        feature = self.extract_feature(imgs)
-        cls_score = self.head(feature, num_segs)
+    def forward_test(self, imgs, labels, reduce_sum, **kwargs):
+        """Define how the model is going to test, from input to output."""
+        #XXX
+        num_segs = imgs.shape[1]
+        cls_score = self(imgs)
 
-        return cls_score
+        # calculate num_crops automatically
+        cls_score = self.average_clip(cls_score, num_segs)
+        metrics = self.head.loss(cls_score, labels, reduce_sum, return_loss=False **kwargs)
+
+        return metrics

--- a/paddlevideo/modeling/heads/base.py
+++ b/paddlevideo/modeling/heads/base.py
@@ -63,7 +63,7 @@ class BaseHead(nn.Layer):
         """
         pass
 
-    def loss(self, scores, labels, reduce_sum=False, **kwargs):
+    def loss(self, scores, labels, reduce_sum=False, return_loss=False, **kwargs):
         """Calculate the loss accroding to the model output ```scores```, 
            and the target ```labels```.
 
@@ -77,9 +77,10 @@ class BaseHead(nn.Layer):
         """
         labels.stop_gradient=True #XXX: check necessary
         losses = dict()
-        #XXX: F.crossentropy include logsoftmax and nllloss 
-        loss = self.loss_func(scores, labels, **kwargs)
-        avg_loss = paddle.mean(loss)
+        if return_loss:
+            #XXX: F.crossentropy include logsoftmax and nllloss 
+            loss = self.loss_func(scores, labels, **kwargs)
+            avg_loss = paddle.mean(loss)
         top1 = paddle.metric.accuracy(input=scores, label=labels, k=1)
         top5 = paddle.metric.accuracy(input=scores, label=labels, k=5)
 
@@ -92,9 +93,10 @@ class BaseHead(nn.Layer):
 
         losses['top1'] = top1
         losses['top5'] = top5
-        if type(loss) is dict:
-            losses.update(avg_loss)
-        else:
-            losses['loss'] = avg_loss
+        if return_loss:
+            if type(loss) is dict:
+                losses.update(avg_loss)
+            else:
+                losses['loss'] = avg_loss
 
         return losses

--- a/paddlevideo/modeling/heads/tsm_head.py
+++ b/paddlevideo/modeling/heads/tsm_head.py
@@ -37,7 +37,7 @@ class TSMHead(TSNHead):
                  in_channels,
                  drop_ratio,
                  std,
-                 **kwargs)->None:
+                 **kwargs):
 
 
         super().__init__(num_classes, in_channels, drop_ratio=drop_ratio, std=std, **kwargs)

--- a/paddlevideo/modeling/heads/tsn_head.py
+++ b/paddlevideo/modeling/heads/tsn_head.py
@@ -62,12 +62,12 @@ class TSNHead(BaseHead):
                     self.in_channels,
                     self.num_classes)
 
-    def init_weight(self):
+    def init_weights(self):
         """Initiate the FC layer parameters"""
 
         weight_init_(self.fc, 'Uniform', 'fc_0.w_0', 'fc_0.b_0', low=-self.stdv, high=self.stdv )
-        self.fc.learning_rate = 2.0
-        self.fc.regularizer = paddle.regularizer.L2Decay(0.)
+        self.fc.bias.learning_rate = 2.0
+        self.fc.bias.regularizer = paddle.regularizer.L2Decay(0.)
 
     def forward(self, x, seg_num):
         

--- a/paddlevideo/tasks/test.py
+++ b/paddlevideo/tasks/test.py
@@ -1,0 +1,62 @@
+# copyright (c) 2020 PaddlePaddle Authors. All Rights Reserve.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import paddle
+from paddlevideo.utils import get_logger 
+from ..loader import build_dataloader
+
+logger = get_logger("paddlevideo")
+def test_model(model,
+               dataset,
+               cfg,
+               weight,
+               parallel=False):
+    """Test model entry
+
+    Args:
+        model (paddle.nn.Layer): The model to be tested.
+        dataset (paddle.dataset): Train dataaset.
+
+
+    """
+    batch_size = cfg.DATASET.get("batch_size", 2)
+    places = paddle.set_device('gpu')
+
+    dataloader_setting = dict(
+        batch_size = batch_size,
+        num_worker = cfg.DATASET.get("num_worker", 0)
+        places = places,
+        drop_last = False,
+        shuffle = False)
+
+    data_loader = build_dataloader(dataset, **dataloader_setting)
+
+    model.eval()
+
+    state_dicts = paddle.load(weight)
+    model.set_state_dict(state_dicts)
+
+    if parallel:
+        model = paddle.DataParallel(model)
+    top1 = []
+    for data in data_loader:
+        with paddle.fluid.dygraph.no_grad():
+            if parallel:
+                outputs = model._layers.test_step(data)
+            else:
+                outputs = model.test_step(data)
+        top1.append(outputs('top1'))
+        logger.info(outputs)
+    logger.info(np.mean(top1))
+
+        

--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -107,6 +107,7 @@ def train_model(model, dataset, cfg, parallel=True, validate=True):
         def evaluate(best):
             model.eval()
             metric_list = build_metric()
+            metric_list.pop('lr')
             tic = time.time()
             for i, data in enumerate(valid_loader):
                 if parallel:
@@ -116,6 +117,7 @@ def train_model(model, dataset, cfg, parallel=True, validate=True):
 
                 # log_metric
                 for name, value in outputs.items():
+
                     metric_list[name].update(value.numpy()[0], batch_size)
                 metric_list['batch_time'].update(time.time() - tic)
                 tic = time.time()
@@ -153,9 +155,7 @@ def train_model(model, dataset, cfg, parallel=True, validate=True):
             save(model.state_dict(),
                  osp.join(output_dir, model_name + "_best.pdparams"))
             best = int(best * 10000) / 10000
-            logger.info(
-                f"Already save the best model (top1 acc){best} weights and optimizer params in epoch {epoch}"
-            )
+            logger.info(f"Already save the best model (top1 acc){best}")
 
         if not validate and epoch % cfg.get("save_interval", 10) == 0:
             save(opt_state_dict, osp.join(output_dir, f"{opt_name}.pdopt"))

--- a/paddlevideo/utils/__init__.py
+++ b/paddlevideo/utils/__init__.py
@@ -18,6 +18,6 @@ from .config import *
 from .logger import setup_logger, coloring, get_logger
 from .record import AverageMeter, build_metric, log_batch, log_epoch
 from .dist_utils import get_dist_info, main_only
-from .save_load import save, load_ckpt
+from .save_load import save, load_ckpt, mkdir
 from .precise_bn import do_preciseBN
 __all__ = ['Registry', 'build']

--- a/paddlevideo/utils/config.py
+++ b/paddlevideo/utils/config.py
@@ -17,10 +17,9 @@ from paddlevideo.utils.logger import coloring, get_logger, setup_logger
 
 __all__ = ['get_config']
 
-#ogger = setup_logger("./", name="paddlevideo", level="INFO")
+logger = setup_logger("./", name="paddlevideo", level="INFO")
 
 
-logger = get_logger("paddlevideo")
 class AttrDict(dict):
     def __getattr__(self, key):
         return self[key]
@@ -64,8 +63,8 @@ def print_dict(d, delimiter=0):
     placeholder = "-" * 60
     for k, v in sorted(d.items()):
         if isinstance(v, dict):
-            logger.info("{}{} : ".format(delimiter * " ", 
-                                         coloring(k, "HEADER")))
+            logger.info("{}{} : ".format(delimiter * " ", coloring(k,
+                                                                   "HEADER")))
             print_dict(v, delimiter + 4)
         elif isinstance(v, list) and len(v) >= 1 and isinstance(v[0], dict):
             logger.info("{}{} : ".format(delimiter * " ",
@@ -105,7 +104,6 @@ def override(dl, ks, v):
         ks(list): list of keys
         v(str): value to be replaced
     """
-
     def str2num(v):
         try:
             return eval(v)
@@ -129,8 +127,8 @@ def override(dl, ks, v):
             dl[ks[0]] = str2num(v)
         else:
             assert ks[0] in dl, (
-                '({}) doesn\'t exist in {}, a new dict field is invalid'.
-                format(ks[0], dl))
+                '({}) doesn\'t exist in {}, a new dict field is invalid'.format(
+                    ks[0], dl))
             override(dl[ks[0]], ks[1:], v)
 
 
@@ -149,8 +147,8 @@ def override_config(config, options=None):
     """
     if options is not None:
         for opt in options:
-            assert isinstance(opt, str), (
-                "option({}) should be a str".format(opt))
+            assert isinstance(opt,
+                              str), ("option({}) should be a str".format(opt))
             assert "=" in opt, (
                 "option({}) should contain a ="
                 "to distinguish between key and value".format(opt))
@@ -167,12 +165,10 @@ def get_config(fname, overrides=None, show=True):
     """
     Read config from file
     """
-    assert os.path.exists(fname), (
-        'config file({}) is not exist'.format(fname))
+    assert os.path.exists(fname), ('config file({}) is not exist'.format(fname))
     config = parse_config(fname)
     override_config(config, overrides)
     if show:
         print_config(config)
     check_config(config)
     return config
-

--- a/paddlevideo/utils/config.py
+++ b/paddlevideo/utils/config.py
@@ -17,8 +17,10 @@ from paddlevideo.utils.logger import coloring, get_logger, setup_logger
 
 __all__ = ['get_config']
 
-logger = setup_logger("./", name="paddlevideo", level="INFO")
+#ogger = setup_logger("./", name="paddlevideo", level="INFO")
 
+
+logger = get_logger("paddlevideo")
 class AttrDict(dict):
     def __getattr__(self, key):
         return self[key]

--- a/paddlevideo/utils/save_load.py
+++ b/paddlevideo/utils/save_load.py
@@ -22,13 +22,14 @@ import paddle
 from paddlevideo.utils import get_logger
 from paddlevideo.utils import main_only
 
+
+#XXX(shipping): maybe need load N times because of different cards have different params.
 @main_only
 def load_ckpt(model, weight_path):
     """
     """
     #model.set_state_dict(state_dict)
-    
-    
+
     if not osp.isfile(weight_path):
         raise IOError(f'{weight_path} is not a checkpoint file')
     #state_dicts = load(weight_path)
@@ -37,24 +38,29 @@ def load_ckpt(model, weight_path):
     state_dicts = paddle.load(weight_path)
     tmp = {}
     total_len = len(model.state_dict())
-    with tqdm(total=total_len, position=1, bar_format='{desc}', desc="Loading weights") as desc:
+    with tqdm(total=total_len,
+              position=1,
+              bar_format='{desc}',
+              desc="Loading weights") as desc:
         for item in tqdm(model.state_dict(), total=total_len, position=0):
             name = item
             desc.set_description('Loading %s' % name)
             tmp[name] = state_dicts[name]
             time.sleep(0.01)
-        ret_str = "loading {:<20d} weights completed.".format(len(model.state_dict()))
+        ret_str = "loading {:<20d} weights completed.".format(
+            len(model.state_dict()))
         desc.set_description(ret_str)
         model.set_state_dict(tmp)
-    
 
-def makedirs(dir):
+
+def mkdir(dir):
     if not os.path.exists(dir):
         # avoid error when train with multiple gpus
         try:
             os.makedirs(dir)
         except:
             pass
+
 
 """
 def save(state_dicts, file_name):
@@ -86,6 +92,7 @@ def save(state_dicts, file_name):
     with open(file_name, 'wb') as f:
         pickle.dump(final_dict, f, protocol=2)
 """
+
 
 @main_only
 def save(obj, path):

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+import os.path as osp
+
+import paddle
+import paddle.nn.functional as F
+from paddle.jit import to_static
+
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../')))
+
+from paddlevideo.modeling.builder import build_model
+from paddlevideo.utils import get_config
+
+def parse_args():
+
+    parser = argparse.ArgumentParser("PaddleVideo test script")
+    parser.add_argument(
+            '-c',
+            '--config',
+            type=str,
+            default='configs/example.yaml',
+            help='config file path')
+
+    parser.add_argument(
+            "-p", 
+            "--pretrained_params",
+            default='./best.pdparams',
+            type=str)
+    parser.add_argument(
+        "-o", "--output_path", type=str, default="./inference")
+    parser.add_argument("--img_size", type=int, default=224)
+
+    return parser.parse_args()
+
+def _trim(cfg):
+    """
+    Reuse the trainging config will bring useless attribute, such as: backbone.pretrained model. Trim it here.
+    """
+    model_name = cfg.model_name
+    cfg = cfg.MODEL
+    cfg.backbone.pretrained = ""
+    return cfg, model_name
+
+def main():
+    args = parse_args()
+    cfg, model_name = _trim(get_config(args.config, show=False))
+    print(f"Building model({model_name})...")
+    model = build_model(cfg)
+    assert osp.isfile(args.pretrained_params) , f"pretrained params ({args.pretrained_params} is not a file path.)"
+
+    assert osp.isdir(args.output_path), f"output path ({args.output_path}) is not a file path"
+    print(f"Loading params from ({args.pretrained_params})...")
+    params = paddle.load(args.pretrained_params)
+    model.set_dict(params)
+    model.eval()
+
+    model = to_static(
+        model,
+        input_spec=[
+            paddle.static.InputSpec(
+                shape=[None, 8, 3, args.img_size, args.img_size], dtype='float32'),
+            #NOTE: Do not pass label.label
+            #paddle.static.InputSpec(
+            #    shape=[None, 1], dtype='int64'
+            #   )
+        ])
+    paddle.jit.save(model, osp.join(args.output_path, model_name))
+    print(f"model ({model_name}) has been already saved in ({args.output_path}).")
+
+if __name__ == "__main__":
+    main()

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import utils
+import numpy as np
+import cv2
+import time
+
+from paddle.inference import Config
+from paddle.inference import create_predictor
+
+
+def create_paddle_predictor(args):
+    config = Config(args.model_file, args.params_file)
+
+    if args.use_gpu:
+        config.enable_use_gpu(args.gpu_mem, 0)
+    else:
+        config.disable_gpu()
+        if args.enable_mkldnn:
+            # cache 10 different shapes for mkldnn to avoid memory leak
+            config.set_mkldnn_cache_capacity(10)
+            config.enable_mkldnn()
+
+    #config.disable_glog_info()
+    config.switch_ir_optim(args.ir_optim)  # default true
+    if args.use_tensorrt:
+        config.enable_tensorrt_engine(
+            precision_mode=Config.Precision.Half
+            if args.use_fp16 else Config.Precision.Float32,
+            max_batch_size=args.batch_size)
+
+    config.enable_memory_optim()
+    # use zero copy
+    config.switch_use_feed_fetch_ops(False)
+    predictor = create_predictor(config)
+
+    return predictor
+
+
+def main(args):
+    if not args.enable_benchmark:
+        assert args.batch_size == 1
+        assert args.use_fp16 is False
+    else:
+        assert args.use_gpu is True
+        assert args.model is not None
+    # HALF precission predict only work when using tensorrt
+    if args.use_fp16 is True:
+        assert args.use_tensorrt is True
+
+    predictor = create_paddle_predictor(args)
+
+    input_names = predictor.get_input_names()
+    input_tensor = predictor.get_input_handle(input_names[0])
+
+    output_names = predictor.get_output_names()
+    output_tensor = predictor.get_output_handle(output_names[0])
+
+    test_num = 500
+    test_time = 0.0
+    if not args.enable_benchmark:
+        # for PaddleHubServing
+        if args.hubserving:
+            img = args.image_file
+        # for predict only
+        else:
+            #img = cv2.imread(args.image_file)[:, :, ::-1]
+            img = utils.decode(args.video_file, args)
+        assert img is not None, "Error in loading image: {}".format(
+            args.video_file)
+        inputs = utils.preprocess(img, args)
+        inputs = np.expand_dims(
+            inputs, axis=0).repeat(
+                args.batch_size, axis=0).copy()
+        #print(inputs.shape)
+        input_tensor.copy_from_cpu(inputs)
+
+        predictor.run()
+
+        output = output_tensor.copy_to_cpu()
+        return utils.postprocess(output, args)
+    else:
+        for i in range(0, test_num + 10):
+            inputs = np.random.rand(args.batch_size, 8, 3, 224,
+                                    224).astype(np.float32)
+            start_time = time.time()
+            input_tensor.copy_from_cpu(inputs)
+
+            predictor.run()
+
+            output = output_tensor.copy_to_cpu()
+            output = output.flatten()
+            if i >= 10:
+                test_time += time.time() - start_time
+            #time.sleep(0.01)  # sleep for T4 GPU
+
+        fp_message = "FP16" if args.use_fp16 else "FP32"
+        trt_msg = "using tensorrt" if args.use_tensorrt else "not using tensorrt"
+        print("{0}\t{1}\t{2}\tbatch size: {3}\ttime(ms): {4}".format(
+            args.model, trt_msg, fp_message, args.batch_size, 1000 * test_time
+            / test_num))
+        exit(0)
+
+
+if __name__ == "__main__":
+    args = utils.parse_args()
+    classes, scores = main(args)
+    print("Current video file: {}".format(args.video_file))
+    print("\ttop-1 class: {0}".format(classes[0]))
+    print("\ttop-1 score: {0}".format(scores[0]))

--- a/tools/predict.sh
+++ b/tools/predict.sh
@@ -1,0 +1,1 @@
+python3 tools/predict.py -v example.avi --model_file "./inference/example.pdmodel" --params_file "./inference/example.pdiparams" --enable_benchmark=True --model="TSM"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,0 +1,2 @@
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+python3 -B -m paddle.distributed.launch --selected_gpus="2"  test.py  --validate -c configs/recognition/tsm/tsm.yaml -o log_level="INFO" -o DATASET.batch_size=16 -o MODEL.backbone.pretrained=""

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import cv2
+import numpy as np
+from PIL import Image
+import os
+import sys
+
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../')))
+
+
+from paddlevideo.loader.pipelines import Scale, CenterCrop, Normalization, Image2Array
+
+
+def parse_args():
+    def str2bool(v):
+        return v.lower() in ("true", "t", "1")
+
+    # general params
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--video_file", type=str)
+    parser.add_argument("--use_gpu", type=str2bool, default=True)
+
+    # params for decode and sample
+    parser.add_argument("--num_seg", type=int, default=8)
+    parser.add_argument("--seg_len", type=int, default=1)
+
+    # params for preprocess
+    parser.add_argument("--short_size", type=int, default=256)
+    parser.add_argument("--target_size", type=int, default=224)
+    parser.add_argument("--normalize", type=str2bool, default=True)
+
+    # params for predict
+    parser.add_argument("--model_file", type=str)
+    parser.add_argument("--params_file", type=str)
+    parser.add_argument("-b", "--batch_size", type=int, default=1)
+    parser.add_argument("--use_fp16", type=str2bool, default=False)
+    parser.add_argument("--ir_optim", type=str2bool, default=True)
+    parser.add_argument("--use_tensorrt", type=str2bool, default=False)
+    parser.add_argument("--gpu_mem", type=int, default=8000)
+    parser.add_argument("--enable_benchmark", type=str2bool, default=False)
+    parser.add_argument("--top_k", type=int, default=1)
+    parser.add_argument("--enable_mkldnn", type=bool, default=False)
+    parser.add_argument("--hubserving", type=str2bool, default=False)
+
+    # params for infer
+    
+    parser.add_argument("--model", type=str)
+    """
+    parser.add_argument("--pretrained_model", type=str)
+    parser.add_argument("--class_num", type=int, default=1000)
+    parser.add_argument(
+        "--load_static_weights",
+        type=str2bool,
+        default=False,
+        help='Whether to load the pretrained weights saved in static mode')
+
+    # parameters for pre-label the images
+    parser.add_argument(
+        "--pre_label_image",
+        type=str2bool,
+        default=False,
+        help="Whether to pre-label the images using the loaded weights")
+    parser.add_argument("--pre_label_out_idr", type=str, default=None)
+    """
+
+    return parser.parse_args()
+
+
+def decode(filepath, args):
+    num_seg = args.num_seg
+    seg_len = args.seg_len
+
+    cap = cv2.VideoCapture(filepath)
+    videolen = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    sampledFrames = []
+    for i in range(videolen):
+        ret, frame = cap.read()
+        # maybe first frame is empty
+        if ret == False:
+            continue
+        img = frame[:, :, ::-1]
+        sampledFrames.append(img)
+    average_dur = int(len(sampledFrames) / num_seg)
+    imgs = []
+    for i in range(num_seg):
+        idx = 0
+        if average_dur >= seg_len:
+            idx = (average_dur - 1) // 2
+            idx += i * average_dur
+        elif average_dur >= 1:
+            idx += i * average_dur
+        else:
+            idx = i
+
+        for jj in range(idx, idx + seg_len):
+            imgbuf = sampledFrames[int(jj % len(sampledFrames))]
+            img = Image.fromarray(imgbuf, mode='RGB')
+            imgs.append(img)
+
+    return imgs
+
+def preprocess(img, args):
+    img = {"imgs":img}
+    resize_op = Scale(short_size=args.short_size)
+    img = resize_op(img)
+    ccrop_op = CenterCrop(target_size=args.target_size)
+    img = ccrop_op(img)
+    to_array = Image2Array()
+    img = to_array(img)
+    if args.normalize:
+        img_mean = [0.485, 0.456, 0.406]
+        img_std = [0.229, 0.224, 0.225]
+        normalize_op = Normalization(mean=img_mean, std=img_std)
+        img = normalize_op(img)
+    return img['imgs']
+
+
+def postprocess(output, args):
+    output = output.flatten()
+    print(output.shape)
+    print(max(output))
+    classes = np.argpartition(output, -args.top_k)[-args.top_k:]
+    print(classes)
+    classes = classes[np.argsort(-output[classes])]
+    scores = output[classes]
+    return classes, scores
+


### PR DESCRIPTION
This PR
- add predict function, which directly calls paddle built-in predictor to predict.
- add test function

for now,  the panorama of PaddleVideo, function level.

| func| build model |backward | loss | metric(top1/5)|predict ret|
|- |:-: |:-: |:-: |:-: |:-:|
|Train|Y|Y|Y|Y||
|Val   |Y|   |Y|Y||
|Test |Y|   |  |Y||
 |Infer(not impl) |Y|   |  |  |Y|
| Predict(py)|||  |  |Y|


- Others:
  - add save_interval and output path to refine save function.
  - fix bugs when saving the best model.
  - refactoring forward to implement inferencing

![image](https://user-images.githubusercontent.com/13645332/101360588-ce4a4f80-38d8-11eb-8a6d-03a26344848c.png)

Because of predictor will sign the forward method as the total graph, and in the old design of PaddleVideo we integrate build_model and build_loss together, so the incorrect results occur, we create new interfaces (train_step, val_step, test_step) to directly call forward_train/val and indirectly call forward to decouple build_loss and build_model now

Todo:
- check shared memory problem
- benchmark