### PR TITLE
remove num_iters in preciseBN 

### DIFF
--- a/configs/recognition/slowfast/slowfast.yaml
+++ b/configs/recognition/slowfast/slowfast.yaml
@@ -121,7 +121,6 @@ METRIC:
 
 PRECISEBN:
   preciseBN_interval: 10
-  num_iters_preciseBN: 200  #default
 
 model_name: SlowFast
 save_interval: 10

--- a/configs/recognition/tsm/pptsm.yaml
+++ b/configs/recognition/tsm/pptsm.yaml
@@ -14,7 +14,7 @@ MODEL: #MODEL field
 DATASET: #DATASET field
     batch_size: 16  #Mandatory, bacth size
     num_workers: 4 #Mandatory, XXX the number of subprocess on each GPU.
-    train: 
+    train:
         format: "FrameDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
         data_prefix: "" #Mandatory, train data root path
         file_path: "data/dataset/ucf101/ucf101_train_split_1_rawframes.txt" #Mandatory, train data index file path
@@ -94,7 +94,7 @@ PIPELINE: #PIPELINE field
 
 OPTIMIZER: #OPTIMIZER field
     name: 'Momentum' #Mandatory, the type of optimizer, associate to the 'paddlevideo/solver/'
-    momentum: 0.9 
+    momentum: 0.9
     learning_rate: #Mandatory, the type of learning rate scheduler, associate to the 'paddlevideo/solver/'
         name: 'PiecewiseDecay'
         boundaries: [40, 60]
@@ -110,7 +110,6 @@ EVALUATION:
 
 PRECISEBN:
   preciseBN_interval: 5     # epoch interval to do preciseBN, default 1.
-  num_iters_preciseBN: 80  # how many batches used to do preciseBN, default 200.
 
 model_name: "ppTSM"
 log_interval: 20 #Optional, the interal of logger, default:10

--- a/paddlevideo/modeling/framework/recognizers/recognizer3d.py
+++ b/paddlevideo/modeling/framework/recognizers/recognizer3d.py
@@ -31,8 +31,8 @@ class Recognizer3D(BaseRecognizer):
     def train_step(self, data_batch, reduce_sum=False):
         """Training step.
         """
-        imgs = [data_batch[0], data_batch[1]]
-        labels = data_batch[2]
+        imgs = data_batch[0:2]
+        labels = data_batch[2:]
 
         # call forward
         cls_score = self(imgs)
@@ -47,7 +47,7 @@ class Recognizer3D(BaseRecognizer):
     def test_step(self, data_batch):
         """Test step.
         """
-        imgs = [data_batch[0], data_batch[1]]
+        imgs = data_batch[0:2]
         # call forward
         loss_metrics = self(imgs)
 

--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -174,9 +174,7 @@ def train_model(cfg, parallel=True, validate=True):
         # use precise bn to improve acc
         if cfg.get("PRECISEBN") and (epoch % cfg.PRECISEBN.preciseBN_interval
                                      == 0 or epoch == cfg.epochs - 1):
-            do_preciseBN(
-                model, train_loader, parallel,
-                min(cfg.PRECISEBN.num_iters_preciseBN, len(train_loader)))
+            do_preciseBN(model, train_loader, parallel)
 
         # 5. Validation
         if validate and epoch % cfg.get("val_interval",


### PR DESCRIPTION
pr内容:
 
移除preciseBN中的num_iters参数，默认用所有训练数据做preciseBN
原因:
(1) dataloader bug: 迭代器未迭代完，进程数不释放，最终导致进程数过多影响训练；
(2) 全量数据做preciseBN理论上对精度有提升效果，但训练耗时会有所增加。

待dataloader bug修复后可重新添加...
