### PR TITLE
Mohui37 patch 1

### DIFF
--- a/tools/paddlevideo_clas.py
+++ b/tools/paddlevideo_clas.py
@@ -291,7 +291,7 @@ class PaddleVideo(object):
         total_result = []
         for filename in video_list:
             if isinstance(filename, str):
-                v = utils.decode(filename, self.args)  #2021.1.20_mohui37
+                v = utils.decode(filename, self.args) 
                 assert v is not None, "Error in loading video: {}".format(
                     filename)
                 inputs = utils.preprocess(v, self.args)

--- a/tools/paddlevideo_clas.py
+++ b/tools/paddlevideo_clas.py
@@ -291,7 +291,7 @@ class PaddleVideo(object):
         total_result = []
         for filename in video_list:
             if isinstance(filename, str):
-                v = utils.decode(filename, self.args) 
+                v = utils.decode(filename, self.args)  
                 assert v is not None, "Error in loading video: {}".format(
                     filename)
                 inputs = utils.preprocess(v, self.args)

--- a/tools/paddlevideo_clas.py
+++ b/tools/paddlevideo_clas.py
@@ -291,7 +291,7 @@ class PaddleVideo(object):
         total_result = []
         for filename in video_list:
             if isinstance(filename, str):
-                v = utils.decode(video, self.args)
+                v = utils.decode(filename, self.args)  #2021.1.20_mohui37
                 assert v is not None, "Error in loading video: {}".format(
                     filename)
                 inputs = utils.preprocess(v, self.args)


### PR DESCRIPTION
PaddleVideo类的predict函数的输入为文件夹时会报错

from ppvideo import PaddleVideo
clas = PaddleVideo(model_name='ppTSM',use_gpu=False,use_tensorrt=False)
video_file='/root/root/ppvideo_tool/video/'
result=clas.predict(video_file)
print(result)

因为源码中这里出错了：
/opt/conda/lib/python3.6/site-packages/ppvideo/tools/paddlevideo_clas.py
293行起：
for filename in video_list:
print(filename)
if isinstance(filename, str):
#v = utils.decode(video, self.args) #原代码
v = utils.decode(filename, self.args) #我认为的正确代码