### PR TITLE
fix pptsm bug

### DIFF
--- a/configs/recognition/tsm/pptsm.yaml
+++ b/configs/recognition/tsm/pptsm.yaml
@@ -2,7 +2,7 @@ MODEL: #MODEL field
     framework: "Recognizer2D" #Mandatory, indicate the type of network, associate to the 'paddlevideo/modeling/framework/' .
     backbone: #Mandatory, indicate the type of backbone, associate to the 'paddlevideo/modeling/backbones/' .
         name: "ResNetTweaksTSM" #Mandatory, The name of backbone.
-        pretrained: "./ResNet50_vd_ssld_v2_pretrained.pdparams" #Optional, pretrained model path.
+        pretrained: "data/ResNet50_vd_ssld_v2_pretrained.pdparams" #Optional, pretrained model path.
         num_seg: 8
         depth: 50 #Optional, the depth of backbone architecture.
     head:
@@ -11,24 +11,26 @@ MODEL: #MODEL field
         in_channels: 2048 #input channel of the extracted feature.
         drop_ratio: 0.5 #the ratio of dropout
         std: 0.01 #std value in params initialization
+        ls_eps: 0.1
 
 DATASET: #DATASET field
     batch_size: 16  #Mandatory, bacth size
+    test_batch_size: 16
     num_workers: 4 #Mandatory, XXX the number of subprocess on each GPU.
     train:
         format: "FrameDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
         data_prefix: "" #Mandatory, train data root path
-        file_path: "data/dataset/ucf101/ucf101_train_split_1_rawframes.txt" #Mandatory, train data index file path
+        file_path: "data/ucf101/ucf101_train_split_1_rawframes.txt" #Mandatory, train data index file path
         suffix: 'img_{:05}.jpg'
     valid:
         format: "FrameDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
         data_prefix: "" #Mandatory, valid data root path
-        file_path: "data/dataset/ucf101/ucf101_val_split_1_rawframes.txt" #Mandatory, valid data index file path
+        file_path: "data/ucf101/ucf101_val_split_1_rawframes.txt" #Mandatory, valid data index file path
         suffix: 'img_{:05}.jpg'
     test:
         format: "FrameDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
         data_prefix: "" #Mandatory, valid data root path
-        file_path: "data/dataset/ucf101/ucf101_val_split_1_rawframes.txt" #Mandatory, valid data index file path
+        file_path: "data/ucf101/ucf101_val_split_1_rawframes.txt" #Mandatory, valid data index file path
         suffix: 'img_{:05}.jpg'
 
 
@@ -104,6 +106,9 @@ OPTIMIZER: #OPTIMIZER field
         name: 'L2'
         value: 2e-4
 
+MIX:
+    name: "Mixup"
+    alpha: 0.2
 
 METRIC:
     name: 'CenterCropMetric'

--- a/configs/recognition/tsm/pptsm_k400.yaml
+++ b/configs/recognition/tsm/pptsm_k400.yaml
@@ -10,6 +10,7 @@ MODEL: #MODEL field
         in_channels: 2048 #input channel of the extracted feature.
         drop_ratio: 0.5 #the ratio of dropout
         std: 0.01 #std value in params initialization
+        ls_eps: 0.1
 
 DATASET: #DATASET field
     batch_size: 16  #Mandatory, bacth size
@@ -103,6 +104,9 @@ OPTIMIZER: #OPTIMIZER field
         name: 'L2'
         value: 2e-4
 
+MIX:
+    name: "Mixup"
+    alpha: 0.2
 
 METRIC:
     name: 'CenterCropMetric'

--- a/configs/recognition/tsm/pptsm_k400.yaml
+++ b/configs/recognition/tsm/pptsm_k400.yaml
@@ -2,7 +2,7 @@ MODEL: #MODEL field
     framework: "Recognizer2D" #Mandatory, indicate the type of network, associate to the 'paddlevideo/modeling/framework/' .
     backbone: #Mandatory, indicate the type of backbone, associate to the 'paddlevideo/modeling/backbones/' .
         name: "ResNetTweaksTSM" #Mandatory, The name of backbone.
-        pretrained: "./ResNet50_vd_ssld_v2_pretrained.pdparams" #Optional, pretrained model path.
+        pretrained: "data/ResNet50_vd_ssld_v2_pretrained.pdparams" #Optional, pretrained model path.
         depth: 50 #Optional, the depth of backbone architecture.
     head:
         name: "TSMHead" #Mandatory, indicate the type of head, associate to the 'paddlevideo/modeling/heads'

--- a/paddlevideo/modeling/framework/recognizers/recognizer2d.py
+++ b/paddlevideo/modeling/framework/recognizers/recognizer2d.py
@@ -21,7 +21,7 @@ logger = get_logger("paddlevideo")
 @RECOGNIZERS.register()
 class Recognizer2D(BaseRecognizer):
     """2D recognizer model framework."""
-    def train_step(self, data_batch, reduce_sum=False):
+    def train_step(self, data_batch):
         """Define how the model is going to train, from input to output.
         """
         #NOTE: As the num_segs is an attribute of dataset phase, and didn't pass to build_head phase, should obtain it from imgs(paddle.Tensor) now, then call self.head method.
@@ -32,13 +32,17 @@ class Recognizer2D(BaseRecognizer):
         imgs = data_batch[0]
         labels = data_batch[1:]
         cls_score = self(imgs)
-        loss_metrics = self.head.loss(cls_score, labels, reduce_sum)
+        loss_metrics = self.head.loss(cls_score, labels)
         return loss_metrics
 
-    def val_step(self, data_batch, reduce_sum=True):
-        return self.train_step(data_batch, reduce_sum=reduce_sum)
+    def val_step(self, data_batch):
+        imgs = data_batch[0]
+        labels = data_batch[1:]
+        cls_score = self(imgs)
+        loss_metrics = self.head.loss(cls_score, labels, valid_mode=True)
+        return loss_metrics
 
-    def test_step(self, data_batch, reduce_sum=False):
+    def test_step(self, data_batch):
         """Define how the model is going to test, from input to output."""
         #NOTE: (shipping) when testing, the net won't call head.loss, we deal with the test processing in /paddlevideo/metrics
         imgs = data_batch[0]

--- a/paddlevideo/modeling/framework/recognizers/recognizer3d.py
+++ b/paddlevideo/modeling/framework/recognizers/recognizer3d.py
@@ -28,7 +28,7 @@ class Recognizer3D(BaseRecognizer):
         cls_score = self.head(feature)
         return cls_score
 
-    def train_step(self, data_batch, reduce_sum=False):
+    def train_step(self, data_batch):
         """Training step.
         """
         imgs = data_batch[0:2]
@@ -36,13 +36,19 @@ class Recognizer3D(BaseRecognizer):
 
         # call forward
         cls_score = self(imgs)
-        loss_metrics = self.head.loss(cls_score, labels, reduce_sum=reduce_sum)
+        loss_metrics = self.head.loss(cls_score, labels)
         return loss_metrics
 
-    def val_step(self, data_batch, reduce_sum=True):
+    def val_step(self, data_batch):
         """Validating setp.
         """
-        return self.train_step(data_batch, reduce_sum=reduce_sum)
+        imgs = data_batch[0:2]
+        labels = data_batch[2:]
+
+        # call forward
+        cls_score = self(imgs)
+        loss_metrics = self.head.loss(cls_score, labels, valid_mode=True)
+        return loss_metrics
 
     def test_step(self, data_batch):
         """Test step.


### PR DESCRIPTION
1. pptsm.yaml和pptsm_k400.yaml配置文件中添加mixup和label_smooth参数；
2. 去除val_step的reduce_sum参数，更名为valid_mode，指定是否为valid模式；
3. 重构head/base.py中的loss部分，修改包括:
 (1)解耦mix_up和label_smooth；
 (2) 解耦loss计算和top1/top5精度计算，代码结构更加清晰；
 (3)添加mix_up下top1和top5计算方法