### PR TITLE
refactoring framework of model forward

### DIFF
--- a/paddlevideo/modeling/framework/localizers/base.py
+++ b/paddlevideo/modeling/framework/localizers/base.py
@@ -38,11 +38,19 @@ class BaseLocalizer(nn.Layer):
         else:
             pass
 
-    def forward(self, imgs):
-        """Call backbone forward.
+    def forward(self, data_batch, mode):
         """
-        preds = self.backbone(imgs)
-        return preds
+        1. Define how the model is going to run, from input to output.
+        2. Console of train, valid, test or infer step
+        """
+        if mode == 'train':
+            return self.train_step(data_batch)
+        elif mode == 'valid':
+            return self.val_step(data_batch)
+        elif mode == 'test':
+            return self.test_step(data_batch)
+        else:
+            raise NotImplementedError
 
     @abstractmethod
     def train_step(self, data_batch, **kwargs):

--- a/paddlevideo/modeling/framework/localizers/bmn_localizer.py
+++ b/paddlevideo/modeling/framework/localizers/bmn_localizer.py
@@ -20,6 +20,12 @@ import paddle
 class BMNLocalizer(BaseLocalizer):
     """BMN Localization framework
     """
+    def forward_net(self, imgs):
+        """Call backbone forward.
+        """
+        preds = self.backbone(imgs)
+        return preds
+
     def train_step(self, data_batch):
         """Training step.
         """
@@ -32,7 +38,7 @@ class BMNLocalizer(BaseLocalizer):
         gt_end.stop_gradient = True
 
         # call Model forward
-        pred_bm, pred_start, pred_end = self(x_data)
+        pred_bm, pred_start, pred_end = self.forward_net(x_data)
         # call Loss forward
         loss = self.loss(pred_bm, pred_start, pred_end, gt_iou_map, gt_start,
                          gt_end)
@@ -58,5 +64,5 @@ class BMNLocalizer(BaseLocalizer):
         gt_end.stop_gradient = True
 
         # call Model forward
-        pred_bm, pred_start, pred_end = self(x_data)
+        pred_bm, pred_start, pred_end = self.forward_net(x_data)
         return pred_bm, pred_start, pred_end

--- a/paddlevideo/modeling/framework/recognizers/recognizer3d.py
+++ b/paddlevideo/modeling/framework/recognizers/recognizer3d.py
@@ -21,10 +21,10 @@ logger = get_logger("paddlevideo")
 class Recognizer3D(BaseRecognizer):
     """3D Recognizer model framework.
     """
-    def forward(self, imgs, **kwargs):
+    def forward_net(self, imgs):
         """Define how the model is going to run, from input to output.
         """
-        feature = self.extract_feature(imgs)
+        feature = self.backbone(imgs)
         cls_score = self.head(feature)
         return cls_score
 
@@ -35,7 +35,7 @@ class Recognizer3D(BaseRecognizer):
         labels = data_batch[2:]
 
         # call forward
-        cls_score = self(imgs)
+        cls_score = self.forward_net(imgs)
         loss_metrics = self.head.loss(cls_score, labels)
         return loss_metrics
 
@@ -46,7 +46,7 @@ class Recognizer3D(BaseRecognizer):
         labels = data_batch[2:]
 
         # call forward
-        cls_score = self(imgs)
+        cls_score = self.forward_net(imgs)
         loss_metrics = self.head.loss(cls_score, labels, valid_mode=True)
         return loss_metrics
 
@@ -55,6 +55,6 @@ class Recognizer3D(BaseRecognizer):
         """
         imgs = data_batch[0:2]
         # call forward
-        cls_score = self(imgs)
+        cls_score = self.forward_net(imgs)
 
         return cls_score

--- a/paddlevideo/tasks/test.py
+++ b/paddlevideo/tasks/test.py
@@ -33,6 +33,7 @@ def test_model(cfg, weights, parallel=True):
 
     """
     # 1. Construct model.
+    cfg.MODEL.backbone.pretrained = ''  # disable pretrain model init
     model = build_model(cfg.MODEL)
     if parallel:
         model = paddle.DataParallel(model)
@@ -63,9 +64,6 @@ def test_model(cfg, weights, parallel=True):
 
     Metric = build_metric(cfg.METRIC)
     for batch_id, data in enumerate(data_loader):
-        if parallel:
-            outputs = model._layers.test_step(data)
-        else:
-            outputs = model.test_step(data)
+        outputs = model(data, mode='test')
         Metric.update(batch_id, data, outputs)
     Metric.accumulate()

--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -132,13 +132,7 @@ def train_model(cfg,
             if amp:
                 with paddle.amp.auto_cast(
                         custom_black_list={"temporal_shift", "reduce_mean"}):
-                    if parallel:
-                        outputs = model._layers.train_step(data)
-                        ## required for DataParallel, will remove in next version
-                        model._reducer.prepare_for_backward(
-                            list(model._find_varbase(outputs)))
-                    else:
-                        outputs = model.train_step(data)
+                    outputs = model(data, mode='train')
 
                 avg_loss = outputs['loss']
                 scaled = scaler.scale(avg_loss)
@@ -148,13 +142,7 @@ def train_model(cfg,
                 optimizer.clear_grad()
 
             else:
-                if parallel:
-                    outputs = model._layers.train_step(data)
-                    ## required for DataParallel, will remove in next version
-                    model._reducer.prepare_for_backward(
-                        list(model._find_varbase(outputs)))
-                else:
-                    outputs = model.train_step(data)
+                outputs = model(data, mode='train')
 
                 # 4.2 backward
                 avg_loss = outputs['loss']
@@ -196,11 +184,7 @@ def train_model(cfg,
             record_list.pop('lr')
             tic = time.time()
             for i, data in enumerate(valid_loader):
-
-                if parallel:
-                    outputs = model._layers.val_step(data)
-                else:
-                    outputs = model.val_step(data)
+                outputs = model(data, mode='valid')
 
                 # log_record
                 for name, value in outputs.items():

--- a/paddlevideo/tasks/train_dali.py
+++ b/paddlevideo/tasks/train_dali.py
@@ -89,13 +89,7 @@ def train_dali(cfg, weights=None, parallel=True):
             data = get_input_data(data)
             record_list['reader_time'].update(time.time() - tic)
             # 4.1 forward
-            if parallel:
-                outputs = model._layers.train_step(data)
-                ## required for DataParallel, will remove in next version
-                model._reducer.prepare_for_backward(
-                    list(model._find_varbase(outputs)))
-            else:
-                outputs = model.train_step(data)
+            outputs = model(data, mode='train')
             # 4.2 backward
             avg_loss = outputs['loss']
             avg_loss.backward()

--- a/paddlevideo/tasks/train_multigrid.py
+++ b/paddlevideo/tasks/train_multigrid.py
@@ -229,13 +229,7 @@ def train_model_multigrid(cfg, world_size=1, validate=True):
         for i, data in enumerate(train_loader):
             record_list['reader_time'].update(time.time() - tic)
             # 4.1 forward
-            if parallel:
-                outputs = model._layers.train_step(data)
-                ## required for DataParallel, will remove in next version
-                model._reducer.prepare_for_backward(
-                    list(model._find_varbase(outputs)))
-            else:
-                outputs = model.train_step(data)
+            outputs = model(data, mode='train')
             # 4.2 backward
             avg_loss = outputs['loss']
             avg_loss.backward()
@@ -275,10 +269,7 @@ def train_model_multigrid(cfg, world_size=1, validate=True):
             record_list.pop('lr')
             tic = time.time()
             for i, data in enumerate(valid_loader):
-                if parallel:
-                    outputs = model._layers.val_step(data)
-                else:
-                    outputs = model.val_step(data)
+                outputs = model(data, mode='valid')
 
                 # log_record
                 for name, value in outputs.items():

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
+start_time=$(date +%s)
+
 # run tsm training
 #python3.7 -B -m paddle.distributed.launch --gpus="0,1,2,3" --log_dir=log_tsm main.py  --validate -c configs/recognition/tsm/tsm.yaml
 
@@ -45,3 +47,7 @@ python3.7 -B -m paddle.distributed.launch --gpus="0,1,2,3"  --log_dir=log_pptsm 
 # predict script
 # just use `example` as example, please replace to real name.
 #python3.7 tools/predict.py -v example.avi --model_file "./inference/example.pdmodel" --params_file "./inference/example.pdiparams" --enable_benchmark=False --model="example" --num_seg=8
+
+end_time=$(date +%s)
+cost_time=$[ $end_time-$start_time ]
+echo "Time to train is $(($cost_time/60))min $(($cost_time%60))s"


### PR DESCRIPTION
1. 去除train.py/test.py中多卡下模型forward时对框架底层model._reducer.prepare_for_backward方法的依赖；
2. 重构framework方法，forward作为控制台，指定不同mode下模型不同的step方法