### PR TITLE
dygraph-to-static benchmark for TSM model

### DIFF
--- a/configs/recognition/tsm/tsm_ucf101_frames.yaml
+++ b/configs/recognition/tsm/tsm_ucf101_frames.yaml
@@ -2,7 +2,7 @@ MODEL: #MODEL field
     framework: "Recognizer2D" #Mandatory, indicate the type of network, associate to the 'paddlevideo/modeling/framework/' .
     backbone: #Mandatory, indicate the type of backbone, associate to the 'paddlevideo/modeling/backbones/' .
         name: "ResNetTSM" #Mandatory, The name of backbone.
-        #pretrained: "data/TSM_k400.pdparams" #Optional, pretrained model path.
+        pretrained: "data/TSM_k400.pdparams" #Optional, pretrained model path.
         num_seg: 8
         depth: 50 #Optional, the depth of backbone architecture.
     head:

--- a/configs/recognition/tsm/tsm_ucf101_frames.yaml
+++ b/configs/recognition/tsm/tsm_ucf101_frames.yaml
@@ -122,6 +122,7 @@ save_interval: 10
 epochs: 25 #Mandatory, total epoch
 log_level: "INFO" #Optional, the logger level. default: "INFO"
 max_iter : 100 # for bench mark
-to_static: False
-enable_pass: False
-amp: False # whether enable amp 
+
+TO_STATIC:
+    enable_to_static: False
+    enable_pass: False

--- a/configs/recognition/tsm/tsm_ucf101_frames.yaml
+++ b/configs/recognition/tsm/tsm_ucf101_frames.yaml
@@ -2,7 +2,7 @@ MODEL: #MODEL field
     framework: "Recognizer2D" #Mandatory, indicate the type of network, associate to the 'paddlevideo/modeling/framework/' .
     backbone: #Mandatory, indicate the type of backbone, associate to the 'paddlevideo/modeling/backbones/' .
         name: "ResNetTSM" #Mandatory, The name of backbone.
-        pretrained: "data/TSM_k400.pdparams" #Optional, pretrained model path.
+        #pretrained: "data/TSM_k400.pdparams" #Optional, pretrained model path.
         num_seg: 8
         depth: 50 #Optional, the depth of backbone architecture.
     head:
@@ -121,3 +121,7 @@ log_interval: 20 #Optional, the interal of logger, default:10
 save_interval: 10
 epochs: 25 #Mandatory, total epoch
 log_level: "INFO" #Optional, the logger level. default: "INFO"
+max_iter : 100 # for bench mark
+to_static: False
+enable_pass: False
+amp: False # whether enable amp 

--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ def main():
                     parallel=parallel,
                     validate=args.validate,
                     use_fleet=args.fleet,
-                    amp=args.amp)
+                    amp=cfg.amp)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ def main():
                     parallel=parallel,
                     validate=args.validate,
                     use_fleet=args.fleet,
-                    amp=cfg.amp)
+                    amp=args.amp)
 
 
 if __name__ == '__main__':

--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -84,6 +84,9 @@ def train_model(cfg,
     mkdir(output_dir)
 
     # 1. Construct model
+
+    # if cfg turns on enable_to_static, change model to static. 
+    # else, the raw model will be returned
     model = build_model(cfg.MODEL)
     apply_to_static(cfg, model)
 

--- a/paddlevideo/utils/__init__.py
+++ b/paddlevideo/utils/__init__.py
@@ -16,6 +16,7 @@ from .registry import Registry
 from .build_utils import build
 from .config import *
 from .logger import setup_logger, coloring, get_logger
+from .to_static import apply_to_static
 from .record import AverageMeter, build_record, log_batch, log_epoch
 from .dist_utils import get_dist_info, main_only
 from .save_load import save, load, load_ckpt, mkdir

--- a/paddlevideo/utils/to_static.py
+++ b/paddlevideo/utils/to_static.py
@@ -1,0 +1,26 @@
+from paddlevideo.utils import get_logger
+import paddle
+
+def apply_to_static(config, model):
+    logger = get_logger("paddlevideo")
+    support_to_static = config.get('TO_STATIC', False)
+    if not support_to_static:
+        return model
+
+    enable_to_static = config['TO_STATIC'].get("enable_to_static", False)
+    if enable_to_static:
+        specs = None #create_input_specs()
+        is_pass = config['TO_STATIC'].get('enable_pass', False)
+        if is_pass:
+            build_strategy = paddle.static.BuildStrategy()
+            build_strategy.fuse_elewise_add_act_ops = True
+            build_strategy.fuse_bn_act_ops = True
+            build_strategy.fuse_bn_add_act_ops = True
+            build_strategy.enable_addto = True
+        else:
+            build_strategy = None
+        model = paddle.jit.to_static(model, input_spec=specs, build_strategy=build_strategy)
+        logger.info("Successfully to apply @to_static with specs: {}".format(
+            specs))
+
+    return model


### PR DESCRIPTION
## What's New ? 

### 1. 背景

目前 Benchamrk 平台上有静态图、动态图的训练数据监控，缺乏 动转静 @to_static 训练的性能监控，因此在 PaddleVideo 动态图训练代码处进行了动转静支持。

### 2. PR内容

选取 TSM 为例，在 config.yaml 中添加 TO_STATIC字段，并且其中的 enable_to_static = True（缺省则表示False）表示模型开启动转静。如果enable_pass=True表示开启pass策略。

只有当模型存在TO_STATIC字段，并且其中的enable_to_static字段=True的时候才会开启动转静。否则还是保持原来的逻辑。

## 3. 启动样例
```bash
python3.7 -B -u main.py -c /tmp/config.yaml -o epochs=1 -o DATASET.num_workers=8 -o log_interval=5  --amp -o TO_STATIC.enable_to_static=True  -o TO_STATIC.enable_pass=True
```

## 4. 影响面

无，兼容性改进。


