### PR TITLE
add movinetA0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: local
     hooks:
     -   id: yapf
@@ -8,7 +9,7 @@
         files: \.py$
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: a11d9314b22d8f8c7556443875b731ef05965464
+    rev: a11d9314b22d8f8c7556443875b731ef05965464
     hooks:
     -   id: check-merge-conflict
     -   id: check-symlinks

--- a/paddlevideo/modeling/movinets/movinets.py
+++ b/paddlevideo/modeling/movinets/movinets.py
@@ -1,0 +1,680 @@
+import collections.abc
+from collections import OrderedDict
+from itertools import repeat
+from typing import Any, Callable, Optional, Tuple, Union
+from typing import List
+
+import paddle
+from einops import rearrange
+from paddle import nn
+
+from movinets_cfg import _C
+
+container_abcs = collections.abc
+
+
+def _ntuple(n):
+    def parse(x):
+        if isinstance(x, container_abcs.Iterable):
+            return x
+        return tuple(repeat(x, n))
+
+    return parse
+
+
+_single = _ntuple(1)
+_pair = _ntuple(2)
+_triple = _ntuple(3)
+_quadruple = _ntuple(4)
+
+
+def _reverse_repeat_tuple(t, n):
+    r"""Reverse the order of `t` and repeat each element for `n` times.
+
+    This can be used to translate padding arg used by Conv and Pooling modules
+    to the ones used by `F.pad`.
+    """
+    return tuple(x for x in reversed(t) for _ in range(n))
+
+
+def _list_with_default(out_size, defaults):
+    # type: (List[int], List[int]) -> List[int]
+    if isinstance(out_size, int):
+        return out_size
+    if len(defaults) <= len(out_size):
+        raise ValueError(
+            'Input dimension should be at least {}'.format(len(out_size) + 1))
+    return [
+        v if v is not None else d
+        for v, d in zip(out_size, defaults[-len(out_size):])
+    ]
+
+
+def _make_divisible(v: float, divisor: int,
+                    min_value: Optional[int] = None) -> int:
+    """
+    This function is taken from the original tf repo.
+    It ensures that all layers have a channel number that is divisible by 8
+    It can be seen here:
+    https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mobilenet.py
+    """
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+def same_padding(x: paddle.Tensor, in_height: int, in_width: int, stride_h: int,
+                 stride_w: int, filter_height: int,
+                 filter_width: int) -> paddle.Tensor:
+    if in_height % stride_h == 0:
+        pad_along_height = max(filter_height - stride_h, 0)
+    else:
+        pad_along_height = max(filter_height - (in_height % stride_h), 0)
+    if in_width % stride_w == 0:
+        pad_along_width = max(filter_width - stride_w, 0)
+    else:
+        pad_along_width = max(filter_width - (in_width % stride_w), 0)
+    pad_top = pad_along_height // 2
+    pad_bottom = pad_along_height - pad_top
+    pad_left = pad_along_width // 2
+    pad_right = pad_along_width - pad_left
+    padding_pad = (pad_left, pad_right, pad_top, pad_bottom)
+    return paddle.nn.functional.pad(x, padding_pad)
+
+
+class Identity(nn.Layer):
+    r"""A placeholder identity operator that is argument-insensitive.
+
+    Args:
+        args: any argument (unused)
+        kwargs: any keyword argument (unused)
+    """
+    def __init__(self, *args, **kwargs):
+        super(Identity, self).__init__()
+
+    def forward(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        return inputs
+
+
+class CausalModule(nn.Layer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.activation = None
+
+    def reset_activation(self) -> None:
+        self.activation = None
+
+
+class TemporalCGAvgPool3D(CausalModule):
+    def __init__(self, ) -> None:
+        super().__init__()
+        self.n_cumulated_values = 0
+        self.register_forward_post_hook(self._detach_activation)
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        input_shape = x.shape
+        cumulative_sum = paddle.cumsum(x, axis=2)
+        if self.activation is None:
+            self.activation = cumulative_sum[:, :, -1:].clone()
+        else:
+            cumulative_sum += self.activation
+            self.activation = cumulative_sum[:, :, -1:].clone()
+
+        noe = paddle.arange(1, input_shape[2] + 1)
+        axis = paddle.to_tensor([0, 1, 3, 4])
+        noe = paddle.unsqueeze(noe, axis=axis)
+        divisor = noe.expand(x.shape)
+        x = cumulative_sum / (self.n_cumulated_values + divisor)
+        self.n_cumulated_values += input_shape[2]
+        return x
+
+    @staticmethod
+    def _detach_activation(module: CausalModule, inputs: paddle.Tensor,
+                           output: paddle.Tensor) -> None:
+        module.activation.detach()
+
+    def reset_activation(self) -> None:
+        super().reset_activation()
+        self.n_cumulated_values = 0
+
+
+class Conv2dBNActivation(nn.Sequential):
+    def __init__(
+            self,
+            in_planes: int,
+            out_planes: int,
+            *,
+            kernel_size: Union[int, Tuple[int, int]],
+            padding: Union[int, Tuple[int, int]],
+            stride: Union[int, Tuple[int, int]] = 1,
+            groups: int = 1,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., paddle.nn.Layer]] = None,
+            **kwargs: Any,
+    ) -> None:
+        kernel_size = _pair(kernel_size)
+        stride = _pair(stride)
+        padding = _pair(padding)
+        if norm_layer is None:
+            norm_layer = Identity
+        if activation_layer is None:
+            activation_layer = Identity
+        self.kernel_size = kernel_size
+        self.stride = stride
+        dict_layers = (nn.Conv2D(in_planes,
+                                 out_planes,
+                                 kernel_size=kernel_size,
+                                 stride=stride,
+                                 padding=padding,
+                                 groups=groups,
+                                 **kwargs), norm_layer(out_planes,
+                                                       momentum=0.1),
+                       activation_layer())
+
+        self.out_channels = out_planes
+        super(Conv2dBNActivation, self).__init__(dict_layers[0], dict_layers[1],
+                                                 dict_layers[2])
+
+
+class Conv3DBNActivation(nn.Sequential):
+    def __init__(
+            self,
+            in_planes: int,
+            out_planes: int,
+            *,
+            kernel_size: Union[int, Tuple[int, int, int]],
+            padding: Union[int, Tuple[int, int, int]],
+            stride: Union[int, Tuple[int, int, int]] = 1,
+            groups: int = 1,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., nn.Layer]] = None,
+            **kwargs: Any,
+    ) -> None:
+        kernel_size = _triple(kernel_size)
+        stride = _triple(stride)
+        padding = _triple(padding)
+        if norm_layer is None:
+            norm_layer = Identity
+        if activation_layer is None:
+            activation_layer = Identity
+        self.kernel_size = kernel_size
+        self.stride = stride
+
+        dict_layers = (
+            nn.Conv3D(in_planes,
+                      out_planes,
+                      kernel_size=kernel_size,
+                      stride=stride,
+                      padding=padding,
+                      groups=groups,
+                      **kwargs),
+            norm_layer(out_planes, momentum=0.1),  # eps=0.001),
+            activation_layer())
+        self.out_channels = out_planes
+        super(Conv3DBNActivation, self).__init__(dict_layers[0], dict_layers[1],
+                                                 dict_layers[2])
+
+
+class ConvBlock3D(CausalModule):
+    def __init__(
+            self,
+            in_planes: int,
+            out_planes: int,
+            *,
+            kernel_size: Union[int, Tuple[int, int, int]],
+            tf_like: bool,
+            causal: bool,
+            conv_type: str,
+            padding: Union[int, Tuple[int, int, int]] = 0,
+            stride: Union[int, Tuple[int, int, int]] = 1,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., nn.Layer]] = None,
+            bias_attr: bool = False,
+            **kwargs: Any,
+    ) -> None:
+        super().__init__()
+        kernel_size = _triple(kernel_size)
+        stride = _triple(stride)
+        padding = _triple(padding)
+        self.conv_2 = None
+        if tf_like:
+            # We neek odd kernel to have even padding
+            # and stride == 1 to precompute padding,
+            if kernel_size[0] % 2 == 0:
+                raise ValueError('tf_like supports only odd' +
+                                 ' kernels for temporal dimension')
+            padding = ((kernel_size[0] - 1) // 2, 0, 0)
+            if stride[0] != 1:
+                raise ValueError('illegal stride value, tf like supports' +
+                                 ' only stride == 1 for temporal dimension')
+            if stride[1] > kernel_size[1] or stride[2] > kernel_size[2]:
+                # these values are not tested so should be avoided
+                raise ValueError('tf_like supports only' +
+                                 '  stride <= of the kernel size')
+
+        if causal is True:
+            padding = (0, padding[1], padding[2])
+        if conv_type != "2plus1d" and conv_type != "3d":
+            raise ValueError("only 2plus2d or 3d are " +
+                             "allowed as 3d convolutions")
+
+        if conv_type == "2plus1d":
+            self.conv_1 = Conv2dBNActivation(in_planes,
+                                             out_planes,
+                                             kernel_size=(kernel_size[1],
+                                                          kernel_size[2]),
+                                             padding=(padding[1], padding[2]),
+                                             stride=(stride[1], stride[2]),
+                                             activation_layer=activation_layer,
+                                             norm_layer=norm_layer,
+                                             bias_attr=bias_attr,
+                                             **kwargs)
+            if kernel_size[0] > 1:
+                self.conv_2 = Conv2dBNActivation(
+                    in_planes,
+                    out_planes,
+                    kernel_size=(kernel_size[0], 1),
+                    padding=(padding[0], 0),
+                    stride=(stride[0], 1),
+                    activation_layer=activation_layer,
+                    norm_layer=norm_layer,
+                    bias_attr=bias_attr,
+                    **kwargs)
+        elif conv_type == "3d":
+            self.conv_1 = Conv3DBNActivation(in_planes,
+                                             out_planes,
+                                             kernel_size=kernel_size,
+                                             padding=padding,
+                                             activation_layer=activation_layer,
+                                             norm_layer=norm_layer,
+                                             stride=stride,
+                                             bias_attr=bias_attr,
+                                             **kwargs)
+        self.padding = padding
+        self.kernel_size = kernel_size
+        self.dim_pad = self.kernel_size[0] - 1
+        self.stride = stride
+        self.causal = causal
+        self.conv_type = conv_type
+        self.tf_like = tf_like
+
+    def _forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.dim_pad > 0 and self.conv_2 is None and self.causal is True:
+            x = self._cat_stream_buffer(x)
+        shape_with_buffer = x.shape
+        if self.conv_type == "2plus1d":
+            x = x.numpy()
+            x = rearrange(x, "b c t h w -> (b t) c h w")
+            x = paddle.to_tensor(x)
+        x = self.conv_1(x)
+        if self.conv_type == "2plus1d":
+            x = x.numpy()
+            x = rearrange(x, "(b t) c h w -> b c t h w", t=shape_with_buffer[2])
+            x = paddle.to_tensor(x)
+            if self.conv_2 is not None:
+                if self.dim_pad > 0 and self.causal is True:
+                    x = self._cat_stream_buffer(x)
+                w = x.shape[-1]
+                x = x.numpy()
+                x = rearrange(x, "b c t h w -> b c t (h w)")
+                x = paddle.to_tensor(x)
+                x = self.conv_2(x)
+                x = x.numpy()
+                x = rearrange(x, "b c t (h w) -> b c t h w", w=w)
+                x = paddle.to_tensor(x)
+        return x
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.tf_like:
+            x = same_padding(x, x.shape[-2], x.shape[-1], self.stride[-2],
+                             self.stride[-1], self.kernel_size[-2],
+                             self.kernel_size[-1])
+        x = self._forward(x)
+        return x
+
+    def _cat_stream_buffer(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.activation is None:
+            self._setup_activation(x.shape)
+        x = paddle.concat((self.activation, x), 2)
+        self._save_in_activation(x)
+        return x
+
+    def _save_in_activation(self, x: paddle.Tensor) -> None:
+        assert self.dim_pad > 0
+        self.activation = paddle.to_tensor(
+            x.numpy()[:, :, -self.dim_pad:, ...]).clone().detach()
+
+    def _setup_activation(self, input_shape: Tuple[float, ...]) -> None:
+        assert self.dim_pad > 0
+        self.activation = paddle.zeros(shape=[
+            *input_shape[:2],  # type: ignore
+            self.dim_pad,
+            *input_shape[3:]
+        ])
+
+
+class SqueezeExcitation(nn.Layer):
+    def __init__(self,
+                 input_channels: int,
+                 activation_2: nn.Layer,
+                 activation_1: nn.Layer,
+                 conv_type: str,
+                 causal: bool,
+                 squeeze_factor: int = 4,
+                 bias_attr: bool = True) -> None:
+        super().__init__()
+        self.causal = causal
+        se_multiplier = 2 if causal else 1
+        squeeze_channels = _make_divisible(
+            input_channels // squeeze_factor * se_multiplier, 8)
+        self.temporal_cumualtive_GAvg3D = TemporalCGAvgPool3D()
+        self.fc1 = ConvBlock3D(input_channels * se_multiplier,
+                               squeeze_channels,
+                               kernel_size=(1, 1, 1),
+                               padding=0,
+                               tf_like=False,
+                               causal=causal,
+                               conv_type=conv_type,
+                               bias_attr=bias_attr)
+        self.activation_1 = activation_1()
+        self.activation_2 = activation_2()
+        self.fc2 = ConvBlock3D(squeeze_channels,
+                               input_channels,
+                               kernel_size=(1, 1, 1),
+                               padding=0,
+                               tf_like=False,
+                               causal=causal,
+                               conv_type=conv_type,
+                               bias_attr=bias_attr)
+
+    def _scale(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        if self.causal:
+            x_space = paddle.mean(inputs, axis=[3, 4], keepdim=True)
+            scale = self.temporal_cumualtive_GAvg3D(x_space)
+            scale = paddle.concat((scale, x_space), axis=1)
+        else:
+            scale = paddle.nn.functional.adaptive_avg_pool3d(inputs, 1)
+        scale = self.fc1(scale)
+        scale = self.activation_1(scale)
+        scale = self.fc2(scale)
+        return self.activation_2(scale)
+
+    def forward(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        scale = self._scale(inputs)
+        return scale * inputs
+
+
+class tfAvgPool3D(nn.Layer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.avgf = paddle.nn.AvgPool3D((1, 3, 3), stride=(1, 2, 2))
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if x.shape[-1] != x.shape[-2]:
+            raise RuntimeError('only same shape for h and w ' +
+                               'are supported by avg with tf_like')
+        if x.shape[-1] != x.shape[-2]:
+            raise RuntimeError('only same shape for h and w ' +
+                               'are supported by avg with tf_like')
+        f1 = x.shape[-1] % 2 != 0
+        if f1:
+            padding_pad = (0, 0, 0, 0)
+        else:
+            padding_pad = (0, 1, 0, 1)
+        x = paddle.nn.functional.pad(x, padding_pad)
+        if f1:
+            x = paddle.nn.functional.avg_pool3d(x, (1, 3, 3),
+                                                stride=(1, 2, 2),
+                                                padding=(0, 1, 1))
+        else:
+            x = self.avgf(x)
+            x[..., -1] = x[..., -1] * 9 / 6
+            x[..., -1, :] = x[..., -1, :] * 9 / 6
+        return x
+
+
+class BasicBneck(nn.Layer):
+    def __init__(
+            self,
+            cfg,
+            causal: bool,
+            tf_like: bool,
+            conv_type: str,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., nn.Layer]] = None,
+    ) -> None:
+        super().__init__()
+        assert type(cfg.stride) is tuple
+        if (not cfg.stride[0] == 1 or not (1 <= cfg.stride[1] <= 2)
+                or not (1 <= cfg.stride[2] <= 2)):
+            raise ValueError('illegal stride value')
+        self.res = None
+
+        layers = []
+        if cfg.expanded_channels != cfg.out_channels:
+            # expand
+            self.expand = ConvBlock3D(in_planes=cfg.input_channels,
+                                      out_planes=cfg.expanded_channels,
+                                      kernel_size=(1, 1, 1),
+                                      padding=(0, 0, 0),
+                                      causal=causal,
+                                      conv_type=conv_type,
+                                      tf_like=tf_like,
+                                      norm_layer=norm_layer,
+                                      activation_layer=activation_layer)
+        # deepwise
+        self.deep = ConvBlock3D(in_planes=cfg.expanded_channels,
+                                out_planes=cfg.expanded_channels,
+                                kernel_size=cfg.kernel_size,
+                                padding=cfg.padding,
+                                stride=cfg.stride,
+                                groups=cfg.expanded_channels,
+                                causal=causal,
+                                conv_type=conv_type,
+                                tf_like=tf_like,
+                                norm_layer=norm_layer,
+                                activation_layer=activation_layer)
+        # SE
+        self.se = SqueezeExcitation(
+            cfg.expanded_channels,
+            causal=causal,
+            activation_1=activation_layer,
+            activation_2=(nn.Sigmoid if conv_type == "3d" else nn.Hardsigmoid),
+            conv_type=conv_type)
+        # project
+        self.project = ConvBlock3D(cfg.expanded_channels,
+                                   cfg.out_channels,
+                                   kernel_size=(1, 1, 1),
+                                   padding=(0, 0, 0),
+                                   causal=causal,
+                                   conv_type=conv_type,
+                                   tf_like=tf_like,
+                                   norm_layer=norm_layer,
+                                   activation_layer=Identity)
+
+        if not (cfg.stride == (1, 1, 1)
+                and cfg.input_channels == cfg.out_channels):
+            if cfg.stride != (1, 1, 1):
+                if tf_like:
+                    layers.append(tfAvgPool3D())
+                else:
+                    layers.append(
+                        paddle.nn.AvgPool3D((1, 3, 3),
+                                            stride=cfg.stride,
+                                            padding=cfg.padding_avg))
+            layers.append(
+                ConvBlock3D(in_planes=cfg.input_channels,
+                            out_planes=cfg.out_channels,
+                            kernel_size=(1, 1, 1),
+                            padding=(0, 0, 0),
+                            norm_layer=norm_layer,
+                            activation_layer=Identity,
+                            causal=causal,
+                            conv_type=conv_type,
+                            tf_like=tf_like))
+            self.res = nn.Sequential(*layers)
+        self.alpha = paddle.static.create_parameter(shape=[1], dtype="float32")
+
+    def forward(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        if self.res is not None:
+            residual = self.res(inputs)
+        else:
+            residual = inputs
+        if self.expand is not None:
+            x = self.expand(inputs)
+        else:
+            x = inputs
+        x = self.deep(x)
+        x = self.se(x)
+        x = self.project(x)
+        result = residual + self.alpha * x
+        return result
+
+
+def _no_grad_zero_(tensor):
+    with paddle.no_grad():
+        return paddle.zeros(tensor.shape)
+
+
+def _no_grad_fill_ones(tensor):
+    with paddle.no_grad():
+        return paddle.ones(shape=tensor.shape)
+
+
+class MoViNet(nn.Layer):
+    def __init__(self,
+                 cfg,
+                 causal: bool = True,
+                 pretrained: bool = False,
+                 num_classes: int = 600,
+                 conv_type: str = "3d",
+                 tf_like: bool = False):
+        super().__init__()
+        if pretrained:
+            tf_like = True
+            num_classes = 600
+            conv_type = "2plus1d" if causal else "3d"
+        blocks_dic = OrderedDict()
+        norm_layer = nn.BatchNorm3D if conv_type == "3d" else nn.BatchNorm2D
+        activation_layer = paddle.nn.Swish if conv_type == "3d" else paddle.nn.Hardswish
+        # conv1
+        self.conv1 = ConvBlock3D(in_planes=cfg.conv1.input_channels,
+                                 out_planes=cfg.conv1.out_channels,
+                                 kernel_size=cfg.conv1.kernel_size,
+                                 stride=cfg.conv1.stride,
+                                 padding=cfg.conv1.padding,
+                                 causal=causal,
+                                 conv_type=conv_type,
+                                 tf_like=tf_like,
+                                 norm_layer=norm_layer,
+                                 activation_layer=activation_layer)
+        for i, block in enumerate(cfg.blocks):
+            for j, basicblock in enumerate(block):
+                blocks_dic[f"b{i}_l{j}"] = BasicBneck(
+                    basicblock,
+                    causal=causal,
+                    conv_type=conv_type,
+                    tf_like=tf_like,
+                    norm_layer=norm_layer,
+                    activation_layer=activation_layer)
+        # self.blocks = nn.LayerDict(blocks_dic)
+        # 本来应该调用这个，由于报错这里强行用了一下paddle.nn.Sequential写死了MoViNetsA0的block
+        self.blocks = nn.Sequential(
+            blocks_dic['b0_l0'], blocks_dic['b1_l0'], blocks_dic['b1_l1'],
+            blocks_dic['b1_l2'], blocks_dic['b2_l0'], blocks_dic['b2_l1'],
+            blocks_dic['b2_l2'], blocks_dic['b3_l0'], blocks_dic['b3_l1'],
+            blocks_dic['b3_l2'], blocks_dic['b3_l3'], blocks_dic['b4_l0'],
+            blocks_dic['b4_l1'], blocks_dic['b4_l2'], blocks_dic['b4_l3'])
+        # conv7
+        self.conv7 = ConvBlock3D(in_planes=cfg.conv7.input_channels,
+                                 out_planes=cfg.conv7.out_channels,
+                                 kernel_size=cfg.conv7.kernel_size,
+                                 stride=cfg.conv7.stride,
+                                 padding=cfg.conv7.padding,
+                                 causal=causal,
+                                 conv_type=conv_type,
+                                 tf_like=tf_like,
+                                 norm_layer=norm_layer,
+                                 activation_layer=activation_layer)
+        # pool
+        self.classifier = nn.Sequential(
+            # dense9
+            ConvBlock3D(cfg.conv7.out_channels,
+                        cfg.dense9.hidden_dim,
+                        kernel_size=(1, 1, 1),
+                        tf_like=tf_like,
+                        causal=causal,
+                        conv_type=conv_type,
+                        bias_attr=True),
+            nn.Swish(),
+            nn.Dropout(p=0.2),
+            # dense10d
+            ConvBlock3D(cfg.dense9.hidden_dim,
+                        num_classes,
+                        kernel_size=(1, 1, 1),
+                        tf_like=tf_like,
+                        causal=causal,
+                        conv_type=conv_type,
+                        bias_attr=True),
+        )
+        if causal:
+            self.cgap = TemporalCGAvgPool3D()
+        else:
+            self.apply(self._weight_init)
+        self.causal = causal
+
+    def avg(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.causal:
+            avg = paddle.nn.functional.adaptive_avg_pool3d(
+                x, (x.shape[2], 1, 1))
+            avg = self.cgap(avg)[:, :, -1:]
+        else:
+            avg = paddle.nn.functional.adaptive_avg_pool3d(x, 1)
+        return avg
+
+    @staticmethod
+    def _weight_init(m):  # TODO check this
+
+        if isinstance(m, nn.Conv3D):
+            nn.initializer.KaimingNormal(m.weight)
+            if m.bias is not None:
+                _no_grad_zero_(m.bias)  # maybe have problems
+        elif isinstance(m, (nn.BatchNorm3D, nn.BatchNorm2D, nn.GroupNorm)):
+            _no_grad_fill_ones(m.weight)
+            _no_grad_zero_(m.bias)
+        elif isinstance(m, nn.Linear):
+            nn.initializer.Normal(m.weight, 0, 0.01)
+            _no_grad_zero_(m.bias)
+
+    def _forward_impl(self, x: paddle.Tensor) -> paddle.Tensor:
+        x = self.conv1(x)
+        x = self.blocks(x)
+        x = self.conv7(x)
+        x = self.avg(x)
+        x = self.classifier(x)
+        x = x.flatten(1)
+        return x
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        return self._forward_impl(x)
+
+    @staticmethod
+    def _clean_activation_buffers(m):
+        if issubclass(type(m), CausalModule):
+            m.reset_activation()
+
+    def clean_activation_buffers(self) -> None:
+        self.apply(self._clean_activation_buffers)
+
+
+if __name__ == '__main__':
+    paddle.set_device("cpu")
+    # paddle.nn.LayerDict的用法可能有一些问题，或者是前面block的初始化有一点问题，所以这里暂时只能调用A0
+    model = MoViNet(cfg=_C.MODEL.MoViNetA0, num_classes=6, causal=True)
+    input_shape = [1, 3, 12, 172, 172]
+    test_data = paddle.ones(shape=input_shape)
+    test_out = model(test_data)

--- a/paddlevideo/modeling/movinets/movinetsA0.py
+++ b/paddlevideo/modeling/movinets/movinetsA0.py
@@ -1,0 +1,890 @@
+import collections.abc
+from collections import OrderedDict
+from itertools import repeat
+from typing import Any, Callable, Optional, Tuple, Union
+from typing import List
+
+import paddle
+from einops import rearrange
+from paddle import nn
+
+container_abcs = collections.abc
+
+
+def _ntuple(n):
+    def parse(x):
+        if isinstance(x, container_abcs.Iterable):
+            return x
+        return tuple(repeat(x, n))
+
+    return parse
+
+
+_single = _ntuple(1)
+_pair = _ntuple(2)
+_triple = _ntuple(3)
+_quadruple = _ntuple(4)
+
+
+def _reverse_repeat_tuple(t, n):
+    r"""Reverse the order of `t` and repeat each element for `n` times.
+
+    This can be used to translate padding arg used by Conv and Pooling modules
+    to the ones used by `F.pad`.
+    """
+    return tuple(x for x in reversed(t) for _ in range(n))
+
+
+def _list_with_default(out_size, defaults):
+    # type: (List[int], List[int]) -> List[int]
+    if isinstance(out_size, int):
+        return out_size
+    if len(defaults) <= len(out_size):
+        raise ValueError(
+            'Input dimension should be at least {}'.format(len(out_size) + 1))
+    return [
+        v if v is not None else d
+        for v, d in zip(out_size, defaults[-len(out_size):])
+    ]
+
+
+def _make_divisible(v: float, divisor: int,
+                    min_value: Optional[int] = None) -> int:
+    """
+    This function is taken from the original tf repo.
+    It ensures that all layers have a channel number that is divisible by 8
+    It can be seen here:
+    https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mobilenet.py
+    """
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+def same_padding(x: paddle.Tensor, in_height: int, in_width: int, stride_h: int,
+                 stride_w: int, filter_height: int,
+                 filter_width: int) -> paddle.Tensor:
+    if in_height % stride_h == 0:
+        pad_along_height = max(filter_height - stride_h, 0)
+    else:
+        pad_along_height = max(filter_height - (in_height % stride_h), 0)
+    if in_width % stride_w == 0:
+        pad_along_width = max(filter_width - stride_w, 0)
+    else:
+        pad_along_width = max(filter_width - (in_width % stride_w), 0)
+    pad_top = pad_along_height // 2
+    pad_bottom = pad_along_height - pad_top
+    pad_left = pad_along_width // 2
+    pad_right = pad_along_width - pad_left
+    padding_pad = (pad_left, pad_right, pad_top, pad_bottom)
+    return paddle.nn.functional.pad(x, padding_pad)
+
+
+class Identity(nn.Layer):
+    r"""A placeholder identity operator that is argument-insensitive.
+
+    Args:
+        args: any argument (unused)
+        kwargs: any keyword argument (unused)
+    """
+    def __init__(self, *args, **kwargs):
+        super(Identity, self).__init__()
+
+    def forward(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        return inputs
+
+
+class CausalModule(nn.Layer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.activation = None
+
+    def reset_activation(self) -> None:
+        self.activation = None
+
+
+class TemporalCGAvgPool3D(CausalModule):
+    def __init__(self, ) -> None:
+        super().__init__()
+        self.n_cumulated_values = 0
+        self.register_forward_post_hook(self._detach_activation)
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        input_shape = x.shape
+        cumulative_sum = paddle.cumsum(x, axis=2)
+        if self.activation is None:
+            self.activation = cumulative_sum[:, :, -1:].clone()
+        else:
+            cumulative_sum += self.activation
+            self.activation = cumulative_sum[:, :, -1:].clone()
+
+        noe = paddle.arange(1, input_shape[2] + 1)
+        axis = paddle.to_tensor([0, 1, 3, 4])
+        noe = paddle.unsqueeze(noe, axis=axis)
+        divisor = noe.expand(x.shape)
+        x = cumulative_sum / (self.n_cumulated_values + divisor)
+        self.n_cumulated_values += input_shape[2]
+        return x
+
+    @staticmethod
+    def _detach_activation(module: CausalModule, inputs: paddle.Tensor,
+                           output: paddle.Tensor) -> None:
+        module.activation.detach()
+
+    def reset_activation(self) -> None:
+        super().reset_activation()
+        self.n_cumulated_values = 0
+
+
+class Conv2dBNActivation(nn.Sequential):
+    def __init__(
+            self,
+            in_planes: int,
+            out_planes: int,
+            *,
+            kernel_size: Union[int, Tuple[int, int]],
+            padding: Union[int, Tuple[int, int]],
+            stride: Union[int, Tuple[int, int]] = 1,
+            groups: int = 1,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., paddle.nn.Layer]] = None,
+            **kwargs: Any,
+    ) -> None:
+        kernel_size = _pair(kernel_size)
+        stride = _pair(stride)
+        padding = _pair(padding)
+        if norm_layer is None:
+            norm_layer = Identity
+        if activation_layer is None:
+            activation_layer = Identity
+        self.kernel_size = kernel_size
+        self.stride = stride
+        dict_layers = (nn.Conv2D(in_planes,
+                                 out_planes,
+                                 kernel_size=kernel_size,
+                                 stride=stride,
+                                 padding=padding,
+                                 groups=groups,
+                                 **kwargs), norm_layer(out_planes,
+                                                       momentum=0.1),
+                       activation_layer())
+
+        self.out_channels = out_planes
+        super(Conv2dBNActivation, self).__init__(dict_layers[0], dict_layers[1],
+                                                 dict_layers[2])
+
+
+class Conv3DBNActivation(nn.Sequential):
+    def __init__(
+            self,
+            in_planes: int,
+            out_planes: int,
+            *,
+            kernel_size: Union[int, Tuple[int, int, int]],
+            padding: Union[int, Tuple[int, int, int]],
+            stride: Union[int, Tuple[int, int, int]] = 1,
+            groups: int = 1,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., nn.Layer]] = None,
+            **kwargs: Any,
+    ) -> None:
+        kernel_size = _triple(kernel_size)
+        stride = _triple(stride)
+        padding = _triple(padding)
+        if norm_layer is None:
+            norm_layer = Identity
+        if activation_layer is None:
+            activation_layer = Identity
+        self.kernel_size = kernel_size
+        self.stride = stride
+
+        dict_layers = (
+            nn.Conv3D(in_planes,
+                      out_planes,
+                      kernel_size=kernel_size,
+                      stride=stride,
+                      padding=padding,
+                      groups=groups,
+                      **kwargs),
+            norm_layer(out_planes, momentum=0.1),  # eps=0.001),
+            activation_layer())
+        self.out_channels = out_planes
+        super(Conv3DBNActivation, self).__init__(dict_layers[0], dict_layers[1],
+                                                 dict_layers[2])
+
+
+class ConvBlock3D(CausalModule):
+    def __init__(
+            self,
+            in_planes: int,
+            out_planes: int,
+            *,
+            kernel_size: Union[int, Tuple[int, int, int]],
+            tf_like: bool,
+            causal: bool,
+            conv_type: str,
+            padding: Union[int, Tuple[int, int, int]] = 0,
+            stride: Union[int, Tuple[int, int, int]] = 1,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., nn.Layer]] = None,
+            bias_attr: bool = False,
+            **kwargs: Any,
+    ) -> None:
+        super().__init__()
+        kernel_size = _triple(kernel_size)
+        stride = _triple(stride)
+        padding = _triple(padding)
+        self.conv_2 = None
+        if tf_like:
+            # We neek odd kernel to have even padding
+            # and stride == 1 to precompute padding,
+            if kernel_size[0] % 2 == 0:
+                raise ValueError('tf_like supports only odd' +
+                                 ' kernels for temporal dimension')
+            padding = ((kernel_size[0] - 1) // 2, 0, 0)
+            if stride[0] != 1:
+                raise ValueError('illegal stride value, tf like supports' +
+                                 ' only stride == 1 for temporal dimension')
+            if stride[1] > kernel_size[1] or stride[2] > kernel_size[2]:
+                # these values are not tested so should be avoided
+                raise ValueError('tf_like supports only' +
+                                 '  stride <= of the kernel size')
+
+        if causal is True:
+            padding = (0, padding[1], padding[2])
+        if conv_type != "2plus1d" and conv_type != "3d":
+            raise ValueError("only 2plus2d or 3d are " +
+                             "allowed as 3d convolutions")
+
+        if conv_type == "2plus1d":
+            self.conv_1 = Conv2dBNActivation(in_planes,
+                                             out_planes,
+                                             kernel_size=(kernel_size[1],
+                                                          kernel_size[2]),
+                                             padding=(padding[1], padding[2]),
+                                             stride=(stride[1], stride[2]),
+                                             activation_layer=activation_layer,
+                                             norm_layer=norm_layer,
+                                             bias_attr=bias_attr,
+                                             **kwargs)
+            if kernel_size[0] > 1:
+                self.conv_2 = Conv2dBNActivation(
+                    in_planes,
+                    out_planes,
+                    kernel_size=(kernel_size[0], 1),
+                    padding=(padding[0], 0),
+                    stride=(stride[0], 1),
+                    activation_layer=activation_layer,
+                    norm_layer=norm_layer,
+                    bias_attr=bias_attr,
+                    **kwargs)
+        elif conv_type == "3d":
+            self.conv_1 = Conv3DBNActivation(in_planes,
+                                             out_planes,
+                                             kernel_size=kernel_size,
+                                             padding=padding,
+                                             activation_layer=activation_layer,
+                                             norm_layer=norm_layer,
+                                             stride=stride,
+                                             bias_attr=bias_attr,
+                                             **kwargs)
+        self.padding = padding
+        self.kernel_size = kernel_size
+        self.dim_pad = self.kernel_size[0] - 1
+        self.stride = stride
+        self.causal = causal
+        self.conv_type = conv_type
+        self.tf_like = tf_like
+
+    def _forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.dim_pad > 0 and self.conv_2 is None and self.causal is True:
+            x = self._cat_stream_buffer(x)
+        shape_with_buffer = x.shape
+        if self.conv_type == "2plus1d":
+            x = x.numpy()
+            x = rearrange(x, "b c t h w -> (b t) c h w")
+            x = paddle.to_tensor(x)
+        x = self.conv_1(x)
+        if self.conv_type == "2plus1d":
+            x = x.numpy()
+            x = rearrange(x, "(b t) c h w -> b c t h w", t=shape_with_buffer[2])
+            x = paddle.to_tensor(x)
+            if self.conv_2 is not None:
+                if self.dim_pad > 0 and self.causal is True:
+                    x = self._cat_stream_buffer(x)
+                w = x.shape[-1]
+                x = x.numpy()
+                x = rearrange(x, "b c t h w -> b c t (h w)")
+                x = paddle.to_tensor(x)
+                x = self.conv_2(x)
+                x = x.numpy()
+                x = rearrange(x, "b c t (h w) -> b c t h w", w=w)
+                x = paddle.to_tensor(x)
+        return x
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.tf_like:
+            x = same_padding(x, x.shape[-2], x.shape[-1], self.stride[-2],
+                             self.stride[-1], self.kernel_size[-2],
+                             self.kernel_size[-1])
+        x = self._forward(x)
+        return x
+
+    def _cat_stream_buffer(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.activation is None:
+            self._setup_activation(x.shape)
+        x = paddle.concat((self.activation, x), 2)
+        self._save_in_activation(x)
+        return x
+
+    def _save_in_activation(self, x: paddle.Tensor) -> None:
+        assert self.dim_pad > 0
+        self.activation = paddle.to_tensor(
+            x.numpy()[:, :, -self.dim_pad:, ...]).clone().detach()
+
+    def _setup_activation(self, input_shape: Tuple[float, ...]) -> None:
+        assert self.dim_pad > 0
+        self.activation = paddle.zeros(shape=[
+            *input_shape[:2],  # type: ignore
+            self.dim_pad,
+            *input_shape[3:]
+        ])
+
+
+class SqueezeExcitation(nn.Layer):
+    def __init__(self,
+                 input_channels: int,
+                 activation_2: nn.Layer,
+                 activation_1: nn.Layer,
+                 conv_type: str,
+                 causal: bool,
+                 squeeze_factor: int = 4,
+                 bias_attr: bool = True) -> None:
+        super().__init__()
+        self.causal = causal
+        se_multiplier = 2 if causal else 1
+        squeeze_channels = _make_divisible(
+            input_channels // squeeze_factor * se_multiplier, 8)
+        self.temporal_cumualtive_GAvg3D = TemporalCGAvgPool3D()
+        self.fc1 = ConvBlock3D(input_channels * se_multiplier,
+                               squeeze_channels,
+                               kernel_size=(1, 1, 1),
+                               padding=0,
+                               tf_like=False,
+                               causal=causal,
+                               conv_type=conv_type,
+                               bias_attr=bias_attr)
+        self.activation_1 = activation_1()
+        self.activation_2 = activation_2()
+        self.fc2 = ConvBlock3D(squeeze_channels,
+                               input_channels,
+                               kernel_size=(1, 1, 1),
+                               padding=0,
+                               tf_like=False,
+                               causal=causal,
+                               conv_type=conv_type,
+                               bias_attr=bias_attr)
+
+    def _scale(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        if self.causal:
+            x_space = paddle.mean(inputs, axis=[3, 4], keepdim=True)
+            scale = self.temporal_cumualtive_GAvg3D(x_space)
+            scale = paddle.concat((scale, x_space), axis=1)
+        else:
+            scale = paddle.nn.functional.adaptive_avg_pool3d(inputs, 1)
+        scale = self.fc1(scale)
+        scale = self.activation_1(scale)
+        scale = self.fc2(scale)
+        return self.activation_2(scale)
+
+    def forward(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        scale = self._scale(inputs)
+        return scale * inputs
+
+
+class tfAvgPool3D(nn.Layer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.avgf = paddle.nn.AvgPool3D((1, 3, 3), stride=(1, 2, 2))
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if x.shape[-1] != x.shape[-2]:
+            raise RuntimeError('only same shape for h and w ' +
+                               'are supported by avg with tf_like')
+        if x.shape[-1] != x.shape[-2]:
+            raise RuntimeError('only same shape for h and w ' +
+                               'are supported by avg with tf_like')
+        f1 = x.shape[-1] % 2 != 0
+        if f1:
+            padding_pad = (0, 0, 0, 0)
+        else:
+            padding_pad = (0, 1, 0, 1)
+        x = paddle.nn.functional.pad(x, padding_pad)
+        if f1:
+            x = paddle.nn.functional.avg_pool3d(x, (1, 3, 3),
+                                                stride=(1, 2, 2),
+                                                padding=(0, 1, 1))
+        else:
+            x = self.avgf(x)
+            x[..., -1] = x[..., -1] * 9 / 6
+            x[..., -1, :] = x[..., -1, :] * 9 / 6
+        return x
+
+
+class BasicBneck(nn.Layer):
+    def __init__(
+            self,
+            cfg,
+            causal: bool,
+            tf_like: bool,
+            conv_type: str,
+            norm_layer: Optional[Callable[..., nn.Layer]] = None,
+            activation_layer: Optional[Callable[..., nn.Layer]] = None,
+    ) -> None:
+        super().__init__()
+        assert type(cfg["stride"]) is tuple
+        if (not cfg["stride"][0] == 1 or not (1 <= cfg["stride"][1] <= 2)
+                or not (1 <= cfg["stride"][2] <= 2)):
+            raise ValueError('illegal stride value')
+        self.res = None
+
+        layers = []
+        if cfg["expanded_channels"] != cfg["out_channels"]:
+            # expand
+            self.expand = ConvBlock3D(in_planes=cfg["input_channels"],
+                                      out_planes=cfg["expanded_channels"],
+                                      kernel_size=(1, 1, 1),
+                                      padding=(0, 0, 0),
+                                      causal=causal,
+                                      conv_type=conv_type,
+                                      tf_like=tf_like,
+                                      norm_layer=norm_layer,
+                                      activation_layer=activation_layer)
+        # deepwise
+        self.deep = ConvBlock3D(in_planes=cfg["expanded_channels"],
+                                out_planes=cfg["expanded_channels"],
+                                kernel_size=cfg["kernel_size"],
+                                padding=cfg["padding"],
+                                stride=cfg["stride"],
+                                groups=cfg["expanded_channels"],
+                                causal=causal,
+                                conv_type=conv_type,
+                                tf_like=tf_like,
+                                norm_layer=norm_layer,
+                                activation_layer=activation_layer)
+        # SE
+        self.se = SqueezeExcitation(
+            cfg["expanded_channels"],
+            causal=causal,
+            activation_1=activation_layer,
+            activation_2=(nn.Sigmoid if conv_type == "3d" else nn.Hardsigmoid),
+            conv_type=conv_type)
+        # project
+        self.project = ConvBlock3D(cfg["expanded_channels"],
+                                   cfg["out_channels"],
+                                   kernel_size=(1, 1, 1),
+                                   padding=(0, 0, 0),
+                                   causal=causal,
+                                   conv_type=conv_type,
+                                   tf_like=tf_like,
+                                   norm_layer=norm_layer,
+                                   activation_layer=Identity)
+
+        if not (cfg["stride"] == (1, 1, 1)
+                and cfg["input_channels"] == cfg["out_channels"]):
+            if cfg["stride"] != (1, 1, 1):
+                if tf_like:
+                    layers.append(tfAvgPool3D())
+                else:
+                    layers.append(
+                        paddle.nn.AvgPool3D((1, 3, 3),
+                                            stride=cfg["stride"],
+                                            padding=cfg["padding_avg"]))
+            layers.append(
+                ConvBlock3D(in_planes=cfg["input_channels"],
+                            out_planes=cfg["out_channels"],
+                            kernel_size=(1, 1, 1),
+                            padding=(0, 0, 0),
+                            norm_layer=norm_layer,
+                            activation_layer=Identity,
+                            causal=causal,
+                            conv_type=conv_type,
+                            tf_like=tf_like))
+            self.res = nn.Sequential(*layers)
+        self.alpha = paddle.static.create_parameter(shape=[1], dtype="float32")
+
+    def forward(self, inputs: paddle.Tensor) -> paddle.Tensor:
+        if self.res is not None:
+            residual = self.res(inputs)
+        else:
+            residual = inputs
+        if self.expand is not None:
+            x = self.expand(inputs)
+        else:
+            x = inputs
+        x = self.deep(x)
+        x = self.se(x)
+        x = self.project(x)
+        result = residual + self.alpha * x
+        return result
+
+
+def _no_grad_zero_(tensor):
+    with paddle.no_grad():
+        return paddle.zeros(tensor.shape)
+
+
+def _no_grad_fill_ones(tensor):
+    with paddle.no_grad():
+        return paddle.ones(shape=tensor.shape)
+
+
+class MoViNet(nn.Layer):
+    def __init__(
+            self,
+            # state_dict_path,
+            causal: bool = True,
+            pretrained: bool = False,
+            num_classes: int = 600,
+            conv_type: str = "3d",
+            tf_like: bool = False):
+        """
+        调用MoViNetA0
+        Args:
+            causal:是否调用因果卷积
+            pretrained: 是否调用预训练模型
+            num_classes: 类别数
+            conv_type: 卷积核类型
+            tf_like: 参考为tensorflow的类型
+        """
+        super().__init__()
+        if pretrained:
+            tf_like = True
+            num_classes = 600
+            conv_type = "2plus1d" if causal else "3d"
+        blocks_dic = OrderedDict()
+        norm_layer = nn.BatchNorm3D if conv_type == "3d" else nn.BatchNorm2D
+        activation_layer = paddle.nn.Swish if conv_type == "3d" else paddle.nn.Hardswish
+        # conv1
+        self.conv1 = ConvBlock3D(in_planes=3,
+                                 out_planes=8,
+                                 kernel_size=(1, 3, 3),
+                                 stride=(1, 2, 2),
+                                 padding=(0, 1, 1),
+                                 causal=causal,
+                                 conv_type=conv_type,
+                                 tf_like=tf_like,
+                                 norm_layer=norm_layer,
+                                 activation_layer=activation_layer)
+        # blocks
+        blocks_dic['b0_l0'] = BasicBneck(cfg={
+            "input_channels": 8,
+            "out_channels": 8,
+            "expanded_channels": 24,
+            "kernel_size": (1, 5, 5),
+            "stride": (1, 2, 2),
+            "padding": (0, 2, 2),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b1_l0'] = BasicBneck(cfg={
+            "input_channels": 8,
+            "out_channels": 32,
+            "expanded_channels": 80,
+            "kernel_size": (3, 3, 3),
+            "stride": (1, 2, 2),
+            "padding": (1, 0, 0),
+            "padding_avg": (0, 0, 0)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b1_l1'] = BasicBneck(cfg={
+            "input_channels": 32,
+            "out_channels": 32,
+            "expanded_channels": 80,
+            "kernel_size": (3, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b1_l2'] = BasicBneck(cfg={
+            "input_channels": 32,
+            "out_channels": 32,
+            "expanded_channels": 80,
+            "kernel_size": (3, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b2_l0'] = BasicBneck(cfg={
+            "input_channels": 32,
+            "out_channels": 56,
+            "expanded_channels": 184,
+            "kernel_size": (5, 3, 3),
+            "stride": (1, 2, 2),
+            "padding": (2, 0, 0),
+            "padding_avg": (0, 0, 0)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b2_l1'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 56,
+            "expanded_channels": 112,
+            "kernel_size": (3, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b2_l2'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 56,
+            "expanded_channels": 184,
+            "kernel_size": (3, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b3_l0'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 56,
+            "expanded_channels": 184,
+            "kernel_size": (5, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (2, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b3_l1'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 56,
+            "expanded_channels": 184,
+            "kernel_size": (5, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b3_l2'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 56,
+            "expanded_channels": 184,
+            "kernel_size": (5, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b3_l3'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 56,
+            "expanded_channels": 184,
+            "kernel_size": (5, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b4_l0'] = BasicBneck(cfg={
+            "input_channels": 56,
+            "out_channels": 104,
+            "expanded_channels": 384,
+            "kernel_size": (5, 3, 3),
+            "stride": (1, 1, 1),
+            "padding": (1, 1, 1),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b4_l1'] = BasicBneck(cfg={
+            "input_channels": 104,
+            "out_channels": 104,
+            "expanded_channels": 280,
+            "kernel_size": (1, 5, 5),
+            "stride": (1, 1, 1),
+            "padding": (0, 2, 2),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b4_l2'] = BasicBneck(cfg={
+            "input_channels": 104,
+            "out_channels": 104,
+            "expanded_channels": 280,
+            "kernel_size": (1, 5, 5),
+            "stride": (1, 1, 1),
+            "padding": (0, 2, 2),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        blocks_dic['b4_l3'] = BasicBneck(cfg={
+            "input_channels": 104,
+            "out_channels": 104,
+            "expanded_channels": 344,
+            "kernel_size": (1, 5, 5),
+            "stride": (1, 1, 1),
+            "padding": (0, 2, 2),
+            "padding_avg": (0, 1, 1)
+        },
+                                         causal=causal,
+                                         conv_type=conv_type,
+                                         tf_like=tf_like,
+                                         norm_layer=norm_layer,
+                                         activation_layer=activation_layer)
+        self.blocks = nn.Sequential(
+            blocks_dic['b0_l0'], blocks_dic['b1_l0'], blocks_dic['b1_l1'],
+            blocks_dic['b1_l2'], blocks_dic['b2_l0'], blocks_dic['b2_l1'],
+            blocks_dic['b2_l2'], blocks_dic['b3_l0'], blocks_dic['b3_l1'],
+            blocks_dic['b3_l2'], blocks_dic['b3_l3'], blocks_dic['b4_l0'],
+            blocks_dic['b4_l1'], blocks_dic['b4_l2'], blocks_dic['b4_l3'])
+        # conv7
+        self.conv7 = ConvBlock3D(in_planes=104,
+                                 out_planes=480,
+                                 kernel_size=(1, 1, 1),
+                                 stride=(1, 1, 1),
+                                 padding=(0, 0, 0),
+                                 causal=causal,
+                                 conv_type=conv_type,
+                                 tf_like=tf_like,
+                                 norm_layer=norm_layer,
+                                 activation_layer=activation_layer)
+        # pool
+        self.classifier = nn.Sequential(
+            # dense9
+            ConvBlock3D(480,
+                        2048,
+                        kernel_size=(1, 1, 1),
+                        tf_like=tf_like,
+                        causal=causal,
+                        conv_type=conv_type,
+                        bias_attr=False),
+            nn.Swish(),
+            # nn.Dropout(p=0.2, inplace=True),
+            nn.Dropout(p=0.2, ),
+            # dense10d
+            ConvBlock3D(2048,
+                        num_classes,
+                        kernel_size=(1, 1, 1),
+                        tf_like=tf_like,
+                        causal=causal,
+                        conv_type=conv_type,
+                        bias_attr=True),
+        )
+        if causal:
+            self.cgap = TemporalCGAvgPool3D()
+        else:
+            self.apply(self._weight_init)
+        self.causal = causal
+
+    def avg(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.causal:
+            avg = paddle.nn.functional.adaptive_avg_pool3d(
+                x, (x.shape[2], 1, 1))
+            avg = self.cgap(avg)[:, :, -1:]
+        else:
+            avg = paddle.nn.functional.adaptive_avg_pool3d(x, 1)
+        return avg
+
+    @staticmethod
+    def _weight_init(m):  # TODO check this
+
+        if isinstance(m, nn.Conv3D):
+            nn.initializer.KaimingNormal(m.weight)
+            if m.bias is not None:
+                _no_grad_zero_(m.bias)  # maybe have problems
+        elif isinstance(m, (nn.BatchNorm3D, nn.BatchNorm2D, nn.GroupNorm)):
+            _no_grad_fill_ones(m.weight)
+            _no_grad_zero_(m.bias)
+        elif isinstance(m, nn.Linear):
+            nn.initializer.Normal(m.weight, 0, 0.01)
+            _no_grad_zero_(m.bias)
+
+    def _forward_impl(self, x: paddle.Tensor) -> paddle.Tensor:
+        x = self.conv1(x)
+        x = self.blocks(x)
+        x = self.conv7(x)
+        x = self.avg(x)
+        x = self.classifier(x)
+        x = x.flatten(1)
+
+        return x
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        return self._forward_impl(x)
+
+    @staticmethod
+    def _clean_activation_buffers(m):
+        if issubclass(type(m), CausalModule):
+            m.reset_activation()
+
+    def clean_activation_buffers(self) -> None:
+        self.apply(self._clean_activation_buffers)
+
+
+if __name__ == '__main__':
+    paddle.set_device("cpu")
+    model = MoViNet(num_classes=6, causal=True)
+    # 1 为batch 3为通道数 12为帧长 172*172是视频文件每一帧的像素值
+    input_shape = [1, 3, 12, 172, 172]
+    test_data = paddle.ones(shape=input_shape)
+    test_out = model(test_data)

--- a/paddlevideo/modeling/movinets/movinets_cfg.py
+++ b/paddlevideo/modeling/movinets/movinets_cfg.py
@@ -1,0 +1,633 @@
+"""
+Inspired by
+https://github.com/PeizeSun/SparseR-CNN/blob/dff4c43a9526a6d0d2480abc833e78a7c29ddb1a/detectron2/config/defaults.py
+"""
+from fvcore.common.config import CfgNode as CN
+
+
+def fill_SE_config(
+        conf,
+        input_channels,
+        out_channels,
+        expanded_channels,
+        kernel_size,
+        stride,
+        padding,
+        padding_avg,
+):
+    conf.expanded_channels = expanded_channels
+    conf.padding_avg = padding_avg
+    fill_conv(
+        conf,
+        input_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+    )
+
+
+def fill_conv(
+        conf,
+        input_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+):
+    conf.input_channels = input_channels
+    conf.out_channels = out_channels
+    conf.kernel_size = kernel_size
+    conf.stride = stride
+    conf.padding = padding
+
+
+_C = CN()
+
+_C.MODEL = CN()
+
+###################
+#### MoViNetA0 ####
+###################
+
+_C.MODEL.MoViNetA0 = CN()
+_C.MODEL.MoViNetA0.name = "A0"
+_C.MODEL.MoViNetA0.conv1 = CN()
+fill_conv(_C.MODEL.MoViNetA0.conv1, 3, 8, (1, 3, 3), (1, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA0.blocks = [[CN()], [CN() for _ in range(3)],
+                             [CN() for _ in range(3)], [CN() for _ in range(4)],
+                             [CN() for _ in range(4)]]
+
+# Block2
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[0][0], 8, 8, 24, (1, 5, 5), (1, 2, 2),
+               (0, 2, 2), (0, 1, 1))
+
+# block 3
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[1][0], 8, 32, 80, (3, 3, 3), (1, 2, 2),
+               (1, 0, 0), (0, 0, 0))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[1][1], 32, 32, 80, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[1][2], 32, 32, 80, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 4
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[2][0], 32, 56, 184, (5, 3, 3),
+               (1, 2, 2), (2, 0, 0), (0, 0, 0))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[2][1], 56, 56, 112, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[2][2], 56, 56, 184, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 5
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[3][0], 56, 56, 184, (5, 3, 3),
+               (1, 1, 1), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[3][1], 56, 56, 184, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[3][2], 56, 56, 184, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[3][3], 56, 56, 184, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 6
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[4][0], 56, 104, 384, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[4][1], 104, 104, 280, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[4][2], 104, 104, 280, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA0.blocks[4][3], 104, 104, 344, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA0.conv7 = CN()
+fill_conv(_C.MODEL.MoViNetA0.conv7, 104, 480, (1, 1, 1), (1, 1, 1), (0, 0, 0))
+
+_C.MODEL.MoViNetA0.dense9 = CN()
+_C.MODEL.MoViNetA0.dense9.hidden_dim = 2048
+
+###################
+#### MoViNetA1 ####
+###################
+
+_C.MODEL.MoViNetA1 = CN()
+_C.MODEL.MoViNetA1.name = "A1"
+_C.MODEL.MoViNetA1.conv1 = CN()
+fill_conv(_C.MODEL.MoViNetA1.conv1, 3, 16, (1, 3, 3), (1, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA1.blocks = [[CN() for _ in range(2)], [CN() for _ in range(4)],
+                             [CN() for _ in range(5)], [CN() for _ in range(6)],
+                             [CN() for _ in range(7)]]
+
+# Block2
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[0][0], 16, 16, 40, (1, 5, 5),
+               (1, 2, 2), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[0][1], 16, 16, 40, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 3
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[1][0], 16, 40, 96, (3, 3, 3),
+               (1, 2, 2), (1, 0, 0), (0, 0, 0))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[1][1], 40, 40, 120, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[1][2], 40, 40, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[1][3], 40, 40, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 4
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[2][0], 40, 64, 216, (5, 3, 3),
+               (1, 2, 2), (2, 0, 0), (0, 0, 0))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[2][1], 64, 64, 128, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[2][2], 64, 64, 216, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[2][3], 64, 64, 168, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[2][4], 64, 64, 216, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 5
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[3][0], 64, 64, 216, (5, 3, 3),
+               (1, 1, 1), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[3][1], 64, 64, 216, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[3][2], 64, 64, 216, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[3][3], 64, 64, 128, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[3][4], 64, 64, 128, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[3][5], 64, 64, 216, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 6
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][0], 64, 136, 456, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][1], 136, 136, 360, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][2], 136, 136, 360, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][3], 136, 136, 360, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][4], 136, 136, 456, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][5], 136, 136, 456, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA1.blocks[4][6], 136, 136, 544, (1, 3, 3),
+               (1, 1, 1), (0, 1, 1), (0, 1, 1))
+
+_C.MODEL.MoViNetA1.conv7 = CN()
+fill_conv(_C.MODEL.MoViNetA1.conv7, 136, 600, (1, 1, 1), (1, 1, 1), (0, 0, 0))
+
+_C.MODEL.MoViNetA1.dense9 = CN()
+_C.MODEL.MoViNetA1.dense9.hidden_dim = 2048
+
+###################
+#### MoViNetA2 ####
+###################
+
+_C.MODEL.MoViNetA2 = CN()
+_C.MODEL.MoViNetA2.name = "A2"
+
+_C.MODEL.MoViNetA2.conv1 = CN()
+fill_conv(_C.MODEL.MoViNetA2.conv1, 3, 16, (1, 3, 3), (1, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA2.blocks = [[CN() for _ in range(3)], [CN() for _ in range(5)],
+                             [CN() for _ in range(5)], [CN() for _ in range(6)],
+                             [CN() for _ in range(7)]]
+
+# Block2
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[0][0], 16, 16, 40, (1, 5, 5),
+               (1, 2, 2), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[0][1], 16, 16, 40, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[0][2], 16, 16, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 3
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[1][0], 16, 40, 96, (3, 3, 3),
+               (1, 2, 2), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[1][1], 40, 40, 120, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[1][2], 40, 40, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[1][3], 40, 40, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[1][4], 40, 40, 120, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 4
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[2][0], 40, 72, 240, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[2][1], 72, 72, 160, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[2][2], 72, 72, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[2][3], 72, 72, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[2][4], 72, 72, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 5
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[3][0], 72, 72, 240, (5, 3, 3),
+               (1, 1, 1), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[3][1], 72, 72, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[3][2], 72, 72, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[3][3], 72, 72, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[3][4], 72, 72, 144, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[3][5], 72, 72, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 6
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][0], 72, 144, 480, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][1], 144, 144, 384, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][2], 144, 144, 384, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][3], 144, 144, 480, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][4], 144, 144, 480, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][5], 144, 144, 480, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA2.blocks[4][6], 144, 144, 576, (1, 3, 3),
+               (1, 1, 1), (0, 1, 1), (0, 1, 1))
+
+_C.MODEL.MoViNetA2.conv7 = CN()
+fill_conv(_C.MODEL.MoViNetA2.conv7, 144, 640, (1, 1, 1), (1, 1, 1), (0, 0, 0))
+
+_C.MODEL.MoViNetA2.dense9 = CN()
+_C.MODEL.MoViNetA2.dense9.hidden_dim = 2048
+
+###################
+#### MoViNetA3 ####
+###################
+
+_C.MODEL.MoViNetA3 = CN()
+_C.MODEL.MoViNetA3.name = "A3"
+_C.MODEL.MoViNetA3.conv1 = CN()
+fill_conv(_C.MODEL.MoViNetA3.conv1, 3, 16, (1, 3, 3), (1, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA3.blocks = [[CN() for _ in range(4)], [CN() for _ in range(6)],
+                             [CN() for _ in range(5)], [CN() for _ in range(8)],
+                             [CN() for _ in range(10)]]
+
+# Block2
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[0][0], 16, 16, 40, (1, 5, 5),
+               (1, 2, 2), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[0][1], 16, 16, 40, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[0][2], 16, 16, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[0][3], 16, 16, 40, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 3
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[1][0], 16, 48, 112, (3, 3, 3),
+               (1, 2, 2), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[1][1], 48, 48, 144, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[1][2], 48, 48, 112, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[1][3], 48, 48, 112, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[1][4], 48, 48, 144, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[1][5], 48, 48, 144, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 4
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[2][0], 48, 80, 240, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[2][1], 80, 80, 152, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[2][2], 80, 80, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[2][3], 80, 80, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[2][4], 80, 80, 240, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 5
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][0], 80, 88, 264, (5, 3, 3),
+               (1, 1, 1), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][1], 88, 88, 264, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][2], 88, 88, 264, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][3], 88, 88, 264, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][4], 88, 88, 160, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][5], 88, 88, 264, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][6], 88, 88, 264, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[3][7], 88, 88, 264, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 6
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][0], 88, 168, 560, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][1], 168, 168, 448, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][2], 168, 168, 448, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][3], 168, 168, 560, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][4], 168, 168, 560, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][5], 168, 168, 560, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][6], 168, 168, 448, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][7], 168, 168, 448, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][8], 168, 168, 560, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA3.blocks[4][9], 168, 168, 672, (1, 3, 3),
+               (1, 1, 1), (0, 1, 1), (0, 1, 1))
+
+_C.MODEL.MoViNetA3.conv7 = CN()
+fill_conv(_C.MODEL.MoViNetA3.conv7, 168, 744, (1, 1, 1), (1, 1, 1), (0, 0, 0))
+
+_C.MODEL.MoViNetA3.dense9 = CN()
+_C.MODEL.MoViNetA3.dense9.hidden_dim = 2048
+
+###################
+#### MoViNetA4 ####
+###################
+
+_C.MODEL.MoViNetA4 = CN()
+_C.MODEL.MoViNetA4.name = "A4"
+_C.MODEL.MoViNetA4.conv1 = CN()
+fill_conv(_C.MODEL.MoViNetA4.conv1, 3, 24, (1, 3, 3), (1, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA4.blocks = [[CN() for _ in range(6)], [CN() for _ in range(9)],
+                             [CN()
+                              for _ in range(9)], [CN() for _ in range(10)],
+                             [CN() for _ in range(13)]]
+
+# Block2
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[0][0], 24, 24, 64, (1, 5, 5),
+               (1, 2, 2), (0, 1, 1), (0, 0, 0))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[0][1], 24, 24, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[0][2], 24, 24, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[0][3], 24, 24, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[0][4], 24, 24, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[0][5], 24, 24, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 3
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][0], 24, 56, 168, (3, 3, 3),
+               (1, 2, 2), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][1], 56, 56, 168, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][2], 56, 56, 136, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][3], 56, 56, 136, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][4], 56, 56, 168, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][5], 56, 56, 168, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][6], 56, 56, 168, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][7], 56, 56, 136, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[1][8], 56, 56, 136, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 4
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][0], 56, 96, 320, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][1], 96, 96, 160, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][2], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][3], 96, 96, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][4], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][5], 96, 96, 160, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][6], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][7], 96, 96, 256, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[2][8], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 5
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][0], 96, 96, 320, (5, 3, 3),
+               (1, 1, 1), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][1], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][2], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][3], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][4], 96, 96, 192, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][5], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][6], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][7], 96, 96, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][8], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[3][9], 96, 96, 320, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 6
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][0], 96, 192, 640, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][1], 192, 192, 512, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][2], 192, 192, 512, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][3], 192, 192, 640, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][4], 192, 192, 640, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][5], 192, 192, 640, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][6], 192, 192, 512, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][7], 192, 192, 512, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][8], 192, 192, 640, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][9], 192, 192, 768, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][10], 192, 192, 640, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][11], 192, 192, 640, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA4.blocks[4][12], 192, 192, 768, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+_C.MODEL.MoViNetA4.conv7 = CN()
+fill_conv(_C.MODEL.MoViNetA4.conv7, 192, 856, (1, 1, 1), (1, 1, 1), (0, 0, 0))
+
+_C.MODEL.MoViNetA4.dense9 = CN()
+_C.MODEL.MoViNetA4.dense9.hidden_dim = 2048
+
+###################
+#### MoViNetA5 ####
+###################
+
+_C.MODEL.MoViNetA5 = CN()
+_C.MODEL.MoViNetA5.name = "A5"
+_C.MODEL.MoViNetA5.conv1 = CN()
+fill_conv(_C.MODEL.MoViNetA5.conv1, 3, 24, (1, 3, 3), (1, 2, 2), (0, 1, 1))
+
+_C.MODEL.MoViNetA5.blocks = [[CN()
+                              for _ in range(6)], [CN() for _ in range(11)],
+                             [CN()
+                              for _ in range(13)], [CN() for _ in range(11)],
+                             [CN() for _ in range(18)]]
+
+# Block2
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[0][0], 24, 24, 64, (1, 5, 5),
+               (1, 2, 2), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[0][1], 24, 24, 64, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[0][2], 24, 24, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[0][3], 24, 24, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[0][4], 24, 24, 96, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[0][5], 24, 24, 64, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 3
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][0], 24, 64, 192, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][1], 64, 64, 152, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][2], 64, 64, 152, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][3], 64, 64, 152, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][4], 64, 64, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][5], 64, 64, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][6], 64, 64, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][7], 64, 64, 152, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][8], 64, 64, 152, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][9], 64, 64, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[1][10], 64, 64, 192, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 4
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][0], 64, 112, 376, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][1], 112, 112, 224, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][2], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][3], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][4], 112, 112, 296, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][5], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][6], 112, 112, 224, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][7], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][8], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][9], 112, 112, 296, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][10], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][11], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[2][12], 112, 112, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 5
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][0], 112, 120, 376, (5, 3, 3),
+               (1, 1, 1), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][1], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][2], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][3], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][4], 120, 120, 224, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][5], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][6], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][7], 120, 120, 224, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][8], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][9], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[3][10], 120, 120, 376, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+# block 6
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][0], 120, 224, 744, (5, 3, 3),
+               (1, 2, 2), (2, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][1], 224, 224, 744, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][2], 224, 224, 600, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][3], 224, 224, 600, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][4], 224, 224, 744, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][5], 224, 224, 744, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][6], 224, 224, 744, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][7], 224, 224, 896, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][8], 224, 224, 600, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][9], 224, 224, 600, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][10], 224, 224, 896, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][11], 224, 224, 744, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][12], 224, 224, 744, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][13], 224, 224, 896, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][14], 224, 224, 600, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][15], 224, 224, 600, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][16], 224, 224, 744, (1, 5, 5),
+               (1, 1, 1), (0, 2, 2), (0, 1, 1))
+fill_SE_config(_C.MODEL.MoViNetA5.blocks[4][17], 224, 224, 744, (3, 3, 3),
+               (1, 1, 1), (1, 1, 1), (0, 1, 1))
+
+_C.MODEL.MoViNetA5.conv7 = CN()
+fill_conv(_C.MODEL.MoViNetA5.conv7, 224, 992, (1, 1, 1), (1, 1, 1), (0, 0, 0))
+
+_C.MODEL.MoViNetA5.dense9 = CN()
+_C.MODEL.MoViNetA5.dense9.hidden_dim = 2048

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ opencv-python==4.2.0.32
 decord==0.4.2
 av==8.0.3
 scipy==1.6.3
+einops
+fvcore==0.1.5.post20210630


### PR DESCRIPTION
用了比较原始的办法实现了movinetA0，调用paddlevideo/modeling/movinets/movinetsA0.py内的MoViNet(num_classes=6)即可实现初始化模型。movinetA0现在可以正常使用和训练。这里训练的时候和寻常的训练不同，有额外的要求，需要在每次调用optimz.clear_grad()之后调用一次model.clean_activation_buffers()，缺失这一行的话训练会直接报错。

若要添加movinetsA1-movinetsA5建议对paddlevideo/modeling/movinets/movinets.py进行修复，里面现在还有报错，报错的原因应该是出在torch.nn.Sequential和paddle.nn.Sequential的区别上，paddle.nn.LayerDict这里测试了也无法使用。