### PR TITLE
fix tipc bug

### DIFF
--- a/docs/en/model_zoo/recognition/pp-timesformer.md
+++ b/docs/en/model_zoo/recognition/pp-timesformer.md
@@ -1,8 +1,8 @@
-[English](../../../zh-CN/model_zoo/recognition/pp-timesformer.md) | Simplified Chinese
+[简体中文](../../../zh-CN/model_zoo/recognition/pp-timesformer.md) | English
 
 # TimeSformer Video Classification Model
 
-## content
+## Content
 
 - [Introduction](#Introduction)
 - [Data](#Data)

--- a/test_tipc/configs/AttentionLSTM/AttentionLSTM_train_infer_python.txt
+++ b/test_tipc/configs/AttentionLSTM/AttentionLSTM_train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 null:null
-DATASET.batch_size:null
+-o DATASET.batch_size:64
 null:null
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/PP-TSM/PP-TSM_train_infer_python.txt
+++ b/test_tipc/configs/PP-TSM/PP-TSM_train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 null:null
-DATASET.batch_size:null
+-o DATASET.batch_size:2
 -o MODEL.backbone.pretrained:'data/ResNet50_vd_ssld_v2_pretrained.pdparams'
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/PP-TSN/PP-TSN_train_infer_python.txt
+++ b/test_tipc/configs/PP-TSN/PP-TSN_train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 null:null
-DATASET.batch_size:null
+-o DATASET.batch_size:2
 -o MODEL.backbone.pretrained:'data/ResNet50_vd_ssld_v2_pretrained.pdparams'
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/TSM/TSM_train_infer_python.txt
+++ b/test_tipc/configs/TSM/TSM_train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 null:null
-DATASET.batch_size:null
+-o DATASET.batch_size:2
 -o MODEL.backbone.pretrained:'data/ResNet50_pretrain.pdparams'
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/TSN/TSN_train_infer_python.txt
+++ b/test_tipc/configs/TSN/TSN_train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 null:null
-DATASET.batch_size:null
+-o DATASET.batch_size:2
 -o MODEL.backbone.pretrained:'data/ResNet50_pretrain.pdparams'
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -72,7 +72,7 @@ if [ ${MODE} = "lite_train_lite_infer" ];then
         tar -xf k400_rawframes_small.tar
         popd
         # download pretrained weights
-        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_vd_ssld_v2_pretrained.pdparams --no-check-certificate
+        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_pretrain.pdparams --no-check-certificate
     elif [ ${model_name} == "TSN" ]; then
         # pretrain lite train data
         pushd ./data/k400
@@ -80,7 +80,7 @@ if [ ${MODE} = "lite_train_lite_infer" ];then
         tar -xf k400_rawframes_small.tar
         popd
         # download pretrained weights
-        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_vd_ssld_v2_pretrained.pdparams --no-check-certificate
+        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_pretrain.pdparams --no-check-certificate
     elif [ ${model_name} == "TimeSformer" ]; then
         # pretrain lite train data
         pushd ./data/k400
@@ -93,8 +93,8 @@ if [ ${MODE} = "lite_train_lite_infer" ];then
         pushd data/yt8m
         ## download & decompression training data
         wget -nc https://videotag.bj.bcebos.com/Data/yt8m_rawframe_small.tar
-        tar -xf yt8m_frame_small.tar
-        python3.7 -m pip install tensorflow-gpu==1.14.0
+        tar -xf yt8m_rawframe_small.tar
+        python3.7 -m pip install tensorflow-gpu==1.14.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
         python3.7 tf2pkl.py ./frame ./pkl_frame/
         ls pkl_frame/train*.pkl > train_small.list # 将train*.pkl的路径写入train_small.list
         ls pkl_frame/validate*.pkl > val_small.list # 将validate*.pkl的路径写入val_small.list
@@ -178,7 +178,7 @@ elif [ ${MODE} = "whole_train_whole_infer" ];then
         wget -nc https://videotag.bj.bcebos.com/PaddleVideo/Data/Kinetic400/val_frames.list
         popd
         # download pretrained weights
-        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_vd_ssld_v2_pretrained.pdparams --no-check-certificate
+        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_pretrain.pdparams --no-check-certificate
     elif [ ${model_name} == "TSN" ]; then
         # pretrain whole train data
         pushd ./data/k400
@@ -192,7 +192,7 @@ elif [ ${MODE} = "whole_train_whole_infer" ];then
         wget -nc https://videotag.bj.bcebos.com/PaddleVideo/Data/Kinetic400/val_frames.list
         popd
         # download pretrained weights
-        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_vd_ssld_v2_pretrained.pdparams --no-check-certificate
+        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_pretrain.pdparams --no-check-certificate
     elif [ ${model_name} == "TimeSformer" ]; then
         # pretrain whole train data
         pushd ./data/k400
@@ -214,7 +214,7 @@ elif [ ${MODE} = "whole_train_whole_infer" ];then
         ## download & decompression training data
         curl data.yt8m.org/download.py | partition=2/frame/train mirror=asia python
         curl data.yt8m.org/download.py | partition=2/frame/validate mirror=asia python
-        python3.7 -m pip install tensorflow-gpu==1.14.0
+        python3.7 -m pip install tensorflow-gpu==1.14.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
         cd ..
         python3.7 tf2pkl.py ./frame ./pkl_frame/
         ls pkl_frame/train*.pkl > train.list # 将train*.pkl的路径写入train.list
@@ -286,7 +286,7 @@ elif [ ${MODE} = "lite_train_whole_infer" ];then
         tar -xf k400_rawframes_small.tar
         popd
         # download pretrained weights
-        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_vd_ssld_v2_pretrained.pdparams --no-check-certificate
+        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_pretrain.pdparams --no-check-certificate
     elif [ ${model_name} == "TSN" ]; then
         # pretrain lite train data
         pushd ./data/k400
@@ -294,7 +294,7 @@ elif [ ${MODE} = "lite_train_whole_infer" ];then
         tar -xf k400_rawframes_small.tar
         popd
         # download pretrained weights
-        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_vd_ssld_v2_pretrained.pdparams --no-check-certificate
+        wget -nc -P ./data https://videotag.bj.bcebos.com/PaddleVideo/PretrainModel/ResNet50_pretrain.pdparams --no-check-certificate
     elif [ ${model_name} == "TimeSformer" ]; then
         # pretrain lite train data
         pushd ./data/k400
@@ -308,8 +308,8 @@ elif [ ${MODE} = "lite_train_whole_infer" ];then
         pushd data/yt8m
         ## download & decompression training data
         wget -nc https://videotag.bj.bcebos.com/Data/yt8m_rawframe_small.tar
-        tar -xf yt8m_frame_small.tar
-        python3.7 -m pip install tensorflow-gpu==1.14.0
+        tar -xf yt8m_rawframe_small.tar
+        python3.7 -m pip install tensorflow-gpu==1.14.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
         python3.7 tf2pkl.py ./frame ./pkl_frame/
         ls pkl_frame/train*.pkl > train_small.list # 将train*.pkl的路径写入train_small.list
         ls pkl_frame/validate*.pkl > val_small.list # 将validate*.pkl的路径写入val_small.list

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -322,6 +322,10 @@ else
                 fi
 
                 set_pretrain=$(func_set_params "${pretrain_model_key}" "${pretrain_model_value}")
+                if [[ $MODE =~ "whole_train" ]]; then
+                    train_batch_key=""
+                    train_batch_value=""
+                fi
                 set_batchsize=$(func_set_params "${train_batch_key}" "${train_batch_value}")
                 if [[ $MODE =~ "whole_train" ]]; then
                     train_param_key1=""


### PR DESCRIPTION
1. 解决lite_train可能会出现的以下问题：
    - [x] TSM的预训练模型不对, resnet50vd -> resnet50
    - [x] TSN的预训练模型不对, resnet50vd -> resnet50
    - [x] AttentionLSTM的tar命令不对, tar -xf yt8m_raw_small.tar -> tar -xf yt8m_rawframe_small.tar
    - [x] PP-TSM的batchsize太大, 16->2
    - [x] PP-TSN的batchsize太大, 32->2
    - [x] AttentionLSTM的batch太大，128->64
    - [x] tensorflow下载过慢，使用清华源
2. 修复pp-timesformer.md的中英文切换显示错误