### PR TITLE
update requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,9 @@ paddlenlp
 lmdb
 moviepy
 SimpleITK
-ppdet
+paddledet
+et_xmlfile
+lap
+motmetrics
+xmltodict
+openpyxl


### PR DESCRIPTION
1. 修复缺少ppdet的错误，除了安装paddledet之外，新增了安装paddledet所需的依赖
et_xmlfile
lap
motmetrics
xmltodict
openpyxl

```bash
python3.7 -m pip install -r requirements.txt --no-deps
...
Successfully installed et-xmlfile-1.1.0 lap-0.4.0 motmetrics-1.2.0 openpyxl-3.0.9 paddledet-2.3.0 xmltodict-0.12.0
```
