### PR TITLE
fix train.py's code & add auto_log in requirements.txt

### DIFF
--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -98,7 +98,7 @@ def train_model(cfg,
         model = paddle.DataParallel(model)
 
     if use_fleet:
-        model = paddle.distributed_model(model)
+        model = fleet.distributed_model(model)
 
     # 2. Construct dataset and dataloader
     train_dataset = build_dataset((cfg.DATASET.train, cfg.PIPELINE.train))

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ lap
 motmetrics
 xmltodict
 openpyxl
+git+https://github.com/LDOUBLEV/AutoLog


### PR DESCRIPTION
1. fix distributed code error in `train.py`.
2. add `auto_log` package to requirements.txt for benchmark option when infering.