### PR TITLE
fix footbal action application inference model exporting issue

### DIFF
--- a/applications/FootballAction/README.md
+++ b/applications/FootballAction/README.md
@@ -394,7 +394,7 @@ python -u scenario_lib/train.py  \
 #### step3.3 LSTM模型转为预测模式
 ```
 ${FootballAction}/train_lstm
-python inference_model.py --config=conf/conf.yaml --weights=$weight_path/LSTM.pdparams --save_dir=$save_dir
+python inference_model.py --config=conf/conf.txt --weights=$weight_path/LSTM.pdparams --save_dir=$save_dir
 ```
 
 ## 使用训练模型推理

--- a/applications/FootballAction/train_lstm/conf/conf.txt
+++ b/applications/FootballAction/train_lstm/conf/conf.txt
@@ -12,6 +12,7 @@ lstm_size_img = 2048
 lstm_size_audio = 1024
 num_classes = 8
 save_dir = "."
+with_bn = True
 
 [TRAIN]
 epoch = 20

--- a/applications/FootballAction/train_lstm/inference_model.py
+++ b/applications/FootballAction/train_lstm/inference_model.py
@@ -26,7 +26,7 @@ except:
 import paddle
 import paddle.fluid as fluid
 
-from utils.config_utils import *
+from scenario_lib.config import *
 import scenario_lib.action_net as action_net
 
 paddle.enable_static()


### PR DESCRIPTION
#375 

reuse the config.txt parser to export the lstm inference model, because there is no yaml utils.

the VideoTag utils.config_utils module can also be copied to get the job done but it does take more codes to fix.