### PR TITLE
Move the set_amp_config parameter to the front and fix comments in train.py

### DIFF
--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -129,7 +129,7 @@ def train_model(cfg,
                                 use_amp=use_amp,
                                 amp_level=amp_level)
 
-    # 4. Construct scalar and convert parameters for amp.
+    # 4. Construct scalar and convert parameters for amp(optional)
     if use_amp:
         scaler = amp.GradScaler(init_loss_scaling=2.0**16,
                                 incr_every_n_steps=2000,
@@ -384,7 +384,7 @@ def train_model(cfg,
                         f"Already save the best model (top1 acc){int(best * 10000) / 10000}"
                     )
 
-        # 6. Save model and optimizer
+        # 10. Save model and optimizer
         if epoch % cfg.get("save_interval", 1) == 0 or epoch == cfg.epochs - 1:
             save(
                 optimizer.state_dict(),

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -355,11 +355,11 @@ else
 
                 set_save_model=$(func_set_params "${save_model_key}" "${save_log}")
                 if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
-                    cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2} ${set_amp_config} "
+                    cmd="${python} ${run_train} ${set_amp_config} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2}  "
                 elif [ ${#ips} -le 26 ];then  # train with multi-gpu
-                    cmd="${python} -B -m paddle.distributed.launch --gpus=\"${gpu}\" ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2} ${set_amp_config}"
+                    cmd="${python} -B -m paddle.distributed.launch --gpus=\"${gpu}\" ${run_train} ${set_amp_config} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2} "
                 else     # train with multi-machine
-                    cmd="${python} -B -m paddle.distributed.launch --ips=${ips} --gpus=\"${gpu}\" ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_batchsize} ${set_train_params1} ${set_train_params2} ${set_amp_config}"
+                    cmd="${python} -B -m paddle.distributed.launch --ips=${ips} --gpus=\"${gpu}\" ${run_train} ${set_amp_config} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_batchsize} ${set_train_params1} ${set_train_params2} "
                 fi
 
                 # run train


### PR DESCRIPTION
1. Move the `${set_amp_config}` parameter to the front to avoid errors.
before movement:
    ```bash
    test_tipc/test_train_inference_python.sh: line 367: --amp: command not found
     Run failed with command - python3.7 main.py  -c configs/recognition/tsm/tsm_k400_frames.yaml --seed 1234 --max_iters=30 -o log_interval=1    -o output_dir=./test_tipc/output/TSM/norm_train_gpus_0_autocast_fp16 -o epochs=1 -o MODEL.backbone.pretrained='data/ResNet50_pretrain.pdparams' -o DATASET.batch_size=30 -o DATASET.train.file_path='data/k400/train_small_frames.list' -o DATASET.valid.file_path='data/k400/val_small_frames.list' -o DATASET.test.file_path='data/k400/val_small_frames.list' --profiler_options=batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile --amp !
    ```

    after movement:
    ```bash
    Run successfully with command - python3.7 main.py  -c configs/recognition/tsm/tsm_k400_frames.yaml --seed 1234 --max_iters=30 -o log_interval=1 --amp    -o output_dir=./test_tipc/output/TSM/norm_train_gpus_0_autocast_fp16 -o epochs=1 -o MODEL.backbone.pretrained='data/ResNet50_pretrain.pdparams' -o DATASET.batch_size=30 -o DATASET.train.file_path='data/k400/train_small_frames.list' -o DATASET.valid.file_path='data/k400/val_small_frames.list' -o DATASET.test.file_path='data/k400/val_small_frames.list' --profiler_options=batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
    ```

3. fix some comments in `train.py`