### PR TITLE
fix TimeSformer and SlowFast models' mkldnn inference config.

### DIFF
--- a/test_tipc/configs/SlowFast/train_infer_python.txt
+++ b/test_tipc/configs/SlowFast/train_infer_python.txt
@@ -39,7 +39,7 @@ infer_export:tools/export_model.py -c configs/recognition/slowfast/slowfast.yaml
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/slowfast/slowfast.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
 --batch_size:1|2
 --use_tensorrt:False|True

--- a/test_tipc/configs/TimeSformer/train_infer_python.txt
+++ b/test_tipc/configs/TimeSformer/train_infer_python.txt
@@ -39,7 +39,7 @@ infer_export:tools/export_model.py -c configs/recognition/timesformer/timesforme
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
 --batch_size:1|2
 --use_tensorrt:False

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -195,8 +195,8 @@ def main():
             InferenceHelper.postprocess(outputs)
     else:
         if args.enable_benchmark:
-            test_video_num = 50
-            num_warmup = 10
+            test_video_num = 12
+            num_warmup = 3
 
             # instantiate auto log
             try:


### PR DESCRIPTION
1. remove TimeSformer and SlowFast models' mkldnn inference config and decrease number of test loop when `enable_benchmark=True`
```bash
# ===========SlowFast lite_train_lite_infer log==================
[33m Run successfully with command - python3.7 main.py --validate -c configs/recognition/slowfast/slowfast.yaml --seed 1234 --max_iters=30      -o output_dir=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null -o epochs=2     -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'    !  [0m
[33m Run successfully with command - python3.7 main.py --test -c configs/recognition/slowfast/slowfast.yaml   -w=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/SlowFast_epoch_00001.pdparams -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'!  [0m
[33m Run successfully with command - python3.7 tools/export_model.py -c configs/recognition/slowfast/slowfast.yaml --save_name inference -p=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/SlowFast_epoch_00001.pdparams -o=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null!  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_False_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_False_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp16 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp16_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp16 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp16_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 -B -m paddle.distributed.launch --gpus="0,1" main.py --validate -c configs/recognition/slowfast/slowfast.yaml --seed 1234 --max_iters=30     -o output_dir=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null -o epochs=2     -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'   !  [0m
[33m Run successfully with command - python3.7 main.py --test -c configs/recognition/slowfast/slowfast.yaml   -w=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/SlowFast_epoch_00001.pdparams -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'!  [0m
[33m Run successfully with command - python3.7 tools/export_model.py -c configs/recognition/slowfast/slowfast.yaml --save_name inference -p=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/SlowFast_epoch_00001.pdparams -o=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null!  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_False_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_False_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp32 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp16 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp16_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=True --use_tensorrt=True --precision=fp16 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_gpu_usetrt_True_precision_fp16_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/slowfast/slowfast.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/SlowFast/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/SlowFast/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_2.log 2>&1 !  [0m

# ===========TimeSformer lite_train_lite_infer log==================
[33m Run successfully with command - python3.7 main.py --validate -c configs/recognition/timesformer/timesformer_k400_videos.yaml --seed 1234 --max_iters=30      -o output_dir=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null -o epochs=2 -o MODEL.backbone.pretrained='data/ViT_base_patch16_224_pretrained.pdparams'   -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'    !  [0m
[33m Run successfully with command - python3.7 main.py --test -c configs/recognition/timesformer/timesformer_k400_videos.yaml   -w=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/TimeSformer_epoch_00001.pdparams -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'!  [0m
[33m Run successfully with command - python3.7 tools/export_model.py -c configs/recognition/timesformer/timesformer_k400_videos.yaml --save_name inference -p=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/TimeSformer_epoch_00001.pdparams -o=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null!  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_gpu_usetrt_False_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_gpu_usetrt_False_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 -B -m paddle.distributed.launch --gpus="0,1" main.py --validate -c configs/recognition/timesformer/timesformer_k400_videos.yaml --seed 1234 --max_iters=30     -o output_dir=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null -o epochs=2 -o MODEL.backbone.pretrained='data/ViT_base_patch16_224_pretrained.pdparams'   -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'   !  [0m
[33m Run successfully with command - python3.7 main.py --test -c configs/recognition/timesformer/timesformer_k400_videos.yaml   -w=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/TimeSformer_epoch_00001.pdparams -o DATASET.train.file_path='data/k400/train_small_videos.list' -o DATASET.valid.file_path='data/k400/val_small_videos.list' -o DATASET.test.file_path='data/k400/val_small_videos.list'!  [0m
[33m Run successfully with command - python3.7 tools/export_model.py -c configs/recognition/timesformer/timesformer_k400_videos.yaml --save_name inference -p=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/TimeSformer_epoch_00001.pdparams -o=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null!  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_gpu_usetrt_False_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=True --use_tensorrt=False --precision=fp32 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_gpu_usetrt_False_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=1 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_1_precision_fp32_batchsize_2.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=1 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_1.log 2>&1 !  [0m
[33m Run successfully with command - python3.7 tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml --use_gpu=False --enable_mkldnn=False --cpu_threads=6 --model_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdmodel --batch_size=2 --input_file=./data/example.avi --enable_benchmark=True --precision=fp32 --params_file=./test_tipc/output/TimeSformer/norm_train_gpus_0,1_autocast_null/inference.pdiparams > ./test_tipc/output/TimeSformer/python_infer_cpu_usemkldnn_False_threads_6_precision_fp32_batchsize_2.log 2>&1 !  [0m

```