### PR TITLE
fix attentionLSTM tipc's config file

### DIFF
--- a/test_tipc/configs/AttentionLSTM/train_amp_infer_python.txt
+++ b/test_tipc/configs/AttentionLSTM/train_amp_infer_python.txt
@@ -21,13 +21,13 @@ amp_train:main.py --amp --amp_level='O2' --validate -c configs/recognition/atten
 null:null
 ##
 ===========================eval_params===========================
-eval:main.py --test -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml --save_name inference
+eval:main.py --test -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml
 -w:./test_tipc/output/AttentionLSTM/AttentionLSTM_epoch_00001.pdparams
 ##
 ===========================infer_params===========================
 -o:inference/AttentionLSTM
 -p:null
-norm_export:tools/export_model.py -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml
+norm_export:tools/export_model.py -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml --save_name inference
 quant_export:null
 fpgm_export:null
 distill_export:null

--- a/test_tipc/configs/AttentionLSTM/train_infer_python.txt
+++ b/test_tipc/configs/AttentionLSTM/train_infer_python.txt
@@ -21,13 +21,13 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:main.py --test -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml --save_name inference
+eval:main.py --test -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml
 -w:./test_tipc/output/AttentionLSTM/AttentionLSTM_epoch_00001.pdparams
 ##
 ===========================infer_params===========================
 -o:inference/AttentionLSTM
 -p:null
-norm_export:tools/export_model.py -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml
+norm_export:tools/export_model.py -c configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml --save_name inference
 quant_export:null
 fpgm_export:null
 distill_export:null


### PR DESCRIPTION
1. move `--save_name inference` to `norm_export` in AttentionLSTM model's tipc config file.