### PR TITLE
Fix slight accuracy diff in multi-gpu test

### DIFF
--- a/paddlevideo/metrics/base.py
+++ b/paddlevideo/metrics/base.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 from abc import abstractmethod
-import numpy as np
+
 import paddle
 from paddlevideo.utils import get_dist_info
 
@@ -25,10 +25,28 @@ class BaseMetric(object):
         _, self.world_size = get_dist_info()
         self.log_interval = log_interval
 
+    def gather_from_gpu(self,
+                        gather_object: paddle.Tensor,
+                        concat_axis=0) -> paddle.Tensor:
+        """gather Tensor from all gpus into a list and concatenate them on `concat_axis`.
+
+        Args:
+            gather_object (paddle.Tensor): gather object Tensor
+            concat_axis (int, optional): axis for concatenation. Defaults to 0.
+
+        Returns:
+            paddle.Tensor: gatherd & concatenated Tensor
+        """
+        gather_object_list = []
+        paddle.distributed.all_gather(gather_object_list, gather_object)
+        return paddle.concat(gather_object_list, axis=concat_axis)
+
     @abstractmethod
     def update(self):
-        raise NotImplemented
+        raise NotImplementedError(
+            "'update' method must be implemented in subclass")
 
     @abstractmethod
     def accumulate(self):
-        raise NotImplemented
+        raise NotImplementedError(
+            "'accumulate' method must be implemented in subclass")

--- a/paddlevideo/metrics/center_crop_metric.py
+++ b/paddlevideo/metrics/center_crop_metric.py
@@ -36,9 +36,9 @@ class CenterCropMetric(BaseMetric):
         """update metrics during each iter
 
         Args:
-            batch_id (int): batch id
-            data (List): batch data
-            outputs (paddle.Tensor): batch outputs from model
+            batch_id (int): iter id of current batch.
+            data (List): list of batched data, such as [inputs, labels]
+            outputs (paddle.Tensor): batched outputs from model
         """
         labels = data[1]
         if self.world_size > 1:

--- a/paddlevideo/tasks/test.py
+++ b/paddlevideo/tasks/test.py
@@ -79,7 +79,7 @@ def test_model(cfg, weights, parallel=True):
     for batch_id, data in enumerate(data_loader):
         if cfg.model_name in [
                 'CFBI'
-        ]:  #for VOS task, dataset for video and dataloader for frames in each video
+        ]:  # for VOS task, dataset for video and dataloader for frames in each video
             Metric.update(batch_id, data, model)
         else:
             outputs = model(data, mode='test')


### PR DESCRIPTION
修复`CenterCropMetric`类在多卡测试时指标计算的误差

修复前的多卡测试逻辑：每个iter每张卡各自计算metrics，然后把metrics gather过来取平均并保存到list中，以list的平均作为最终指标
存在的问题：在多卡测试时为了数据能被均匀分配给每张卡，即要满足len(data) % num_gpu == 0，可能会通过resample在data末尾补上少量样本，因此修复前的测试逻辑中最后一个iter的metrics会受resample的影响，从而影响整个测试精度。

修复后的多卡测试逻辑：每个iter仅储存outputs和labels，然后gather outputs和labels，并维护一个剩余样本数量rest_data_size来过滤掉resample产生的数据，然后再存入list，最终用全部样本的outputs和labels一次性计算metrics

自测验证，以共6种不同的gpu和batchsize配置进行验证：
```shell
# 1gpux1bs（参考精度）
python3.7 main.py --test -c configs/recognition/tsm/tsm_ucf101_videos.yaml -w "data/TSM_ucf101_nchw.pdparams"
[06/04 03:07:44] [TEST] Processing batch 3782/3783 ...
[06/04 03:07:44] [TEST] finished, avg_acc1=0.9418451189994812, avg_acc5=0.995506227016449
# 1gpux128bs
python3.7 main.py --test -c configs/recognition/tsm/tsm_ucf101_videos.yaml -w "data/TSM_ucf101_nchw.pdparams" -o DATASET.test_batch_size=128
[06/04 03:11:25] [TEST] Processing batch 29/29 ...
[06/04 03:11:25] [TEST] finished, avg_acc1=0.9418451189994812, avg_acc5=0.995506227016449
# 2gpux128bs
python3.7 -B -m paddle.distributed.launch --gpus="0,1" --log_dir=log_test_2gpu_bs128 main.py --test -c configs/recognition/tsm/tsm_ucf101_videos.yaml -w "data/TSM_ucf101_nchw.pdparams" -o DATASET.test_batch_size=128
[06/04 03:13:42] [TEST] Processing batch 14/14 ...
[06/04 03:13:43] [TEST] finished, avg_acc1=0.9418451189994812, avg_acc5=0.995506227016449
# 3gpux128bs
python3.7 -B -m paddle.distributed.launch --gpus="0,1,2" --log_dir=log_test_3gpu_bs128 main.py --test -c configs/recognition/tsm/tsm_ucf101_videos.yaml -w "data/TSM_ucf101_nchw.pdparams" -o DATASET.test_batch_size=128
[06/04 03:15:28] [TEST] Processing batch 9/9 ...
[06/04 03:15:30] [TEST] finished, avg_acc1=0.9418451189994812, avg_acc5=0.995506227016449
# 4gpux128bs
python3.7 -B -m paddle.distributed.launch --gpus="0,1,2,3" --log_dir=log_test_4gpu_bs128 main.py --test -c configs/recognition/tsm/tsm_ucf101_videos.yaml -w "data/TSM_ucf101_nchw.pdparams" -o DATASET.test_batch_size=128
[06/04 03:17:01] [TEST] Processing batch 7/7 ...
[06/04 03:17:02] [TEST] finished, avg_acc1=0.9418451189994812, avg_acc5=0.995506227016449
# 3gpux37bs
python3.7 -B -m paddle.distributed.launch --gpus="0,1,2" --log_dir=log_test_3gpu_bs37 main.py --test -c configs/recognition/tsm/tsm_ucf101_videos.yaml -w "data/TSM_ucf101_nchw.pdparams" -o DATASET.test_batch_size=37
[06/04 03:18:44] [TEST] Processing batch 34/34 ...
[06/04 03:18:45] [TEST] finished, avg_acc1=0.9418451189994812, avg_acc5=0.995506227016449
```
可以看到6种配置下的精度完全一致