### PR TITLE
update TIPC for benchmark

### DIFF
--- a/configs/localization/bmn.yaml
+++ b/configs/localization/bmn.yaml
@@ -19,7 +19,7 @@ DATASET: #DATASET field
     train:
         format: "BMNDataset"
         file_path: "data/bmn_data/activitynet_1.3_annotations.json"
-        subset: "train"
+        subset: "training"
     valid:
         format: "BMNDataset"
         file_path: "data/bmn_data/activitynet_1.3_annotations.json"

--- a/configs/localization/bmn.yaml
+++ b/configs/localization/bmn.yaml
@@ -19,7 +19,7 @@ DATASET: #DATASET field
     train:
         format: "BMNDataset"
         file_path: "data/bmn_data/activitynet_1.3_annotations.json"
-        subset: "training"
+        subset: "train"
     valid:
         format: "BMNDataset"
         file_path: "data/bmn_data/activitynet_1.3_annotations.json"

--- a/configs/recognition/agcn2s/agcn2s_ntucs_joint_fsd.yaml
+++ b/configs/recognition/agcn2s/agcn2s_ntucs_joint_fsd.yaml
@@ -3,16 +3,16 @@ MODEL: #MODEL field
   backbone: #Mandatory, indicate the type of backbone, associate to the 'paddlevideo/modeling/backbones/' .
     name: "AGCN2s" #Mandatory, The name of backbone.
     num_point: 25
-    num_person: 2
+    num_person: 1
     graph: "ntu_rgb_d"
     graph_args:
       labeling_mode: "spatial"
-    in_channels: 3
+    in_channels: 2
   head:
     name: "AGCN2sHead" #Mandatory, indicate the type of head, associate to the 'paddlevideo/modeling/heads'
     num_classes: 60  #Optional, the number of classes to be classified.
     in_channels: 64  #output the number of classes.
-    M: 2  #number of people.
+    M: 1  #number of people.
 
 DATASET: #DATASET field
   batch_size: 64 #Mandatory, bacth size
@@ -21,41 +21,33 @@ DATASET: #DATASET field
   test_num_workers: 0
   train:
     format: "SkeletonDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
-    file_path: "train_data.npy" #Mandatory, train data index file path
-    label_path: "train_label.npy"
+    file_path: "data/fsd10/FSD_train_data.npy" #Mandatory, train data index file path
+    label_path: "data/fsd10/FSD_train_label.npy"
   test:
     format: "SkeletonDataset" #Mandatory, indicate the type of dataset, associate to the 'paddlevidel/loader/dateset'
-    file_path: "test_A_data.npy" #Mandatory, valid data index file path
+    file_path: "data/fsd10/test_A_data.npy" #Mandatory, valid data index file path
     test_mode: True
 
 
 PIPELINE: #PIPELINE field
   train: #Mandotary, indicate the pipeline to deal with the training data, associate to the 'paddlevideo/loader/pipelines/'
     sample:
-      - Iden:
       name: "AutoPadding"
       window_size: 300
     transform: #Mandotary, image transfrom operator
-      - SketeonModalityTransform:
-          joint: True
-          bone: False
-          motion: False
-          graph: 'ntu_rgb_d'
+      - SkeletonNorm:
   test: #Mandotary, indicate the pipeline to deal with the training data, associate to the 'paddlevideo/loader/pipelines/'
     sample:
       name: "AutoPadding"
       window_size: 300
     transform: #Mandotary, image transfrom operator
-      - SketeonModalityTransform:
-          joint: True
-          bone: False
-          motion: False
-          graph: 'ntu_rgb_d'
+      - SkeletonNorm:
 
 OPTIMIZER: #OPTIMIZER field
   name: 'Momentum'
   momentum: 0.9
   learning_rate:
+    iter_step: True
     name: 'CustomWarmupAdjustDecay'
     step_base_lr: 0.1
     warmup_epochs: 5
@@ -71,14 +63,15 @@ METRIC:
   name: 'SkeletonMetric'
   out_file: 'submission.csv'
 
-INFERENCE:
-  name: 'AGCN2s_Inference_helper'
-  num_channels: 3
-  vertex_nums: 25
-  person_nums: 2
-  window_size: 300
 
-model_name: "AGCN2s_cs_joint"
+INFERENCE:
+    name: 'STGCN_Inference_helper'
+    num_channels: 2
+    window_size: 350
+    vertex_nums: 25
+    person_nums: 1
+
+model_name: "AGCN2s"
 log_interval: 10 #Optional, the interal of logger, default:10
 epochs: 50 #Mandatory, total epoch
 save_interval: 10

--- a/configs/recognition/slowfast/slowfast.yaml
+++ b/configs/recognition/slowfast/slowfast.yaml
@@ -19,7 +19,7 @@ MODEL: #MODEL field
 
 DATASET: #DATASET field
     batch_size: 8  #single card bacth size
-    test_batch_size: 8
+    #test_batch_size: 8
     num_workers: 8
     train:
         format: "SFVideoDataset"

--- a/paddlevideo/modeling/backbones/agcn2s.py
+++ b/paddlevideo/modeling/backbones/agcn2s.py
@@ -195,7 +195,7 @@ class AGCN2s(nn.Layer):
         A = self.graph.A
         self.data_bn = nn.BatchNorm1D(num_person * in_channels * num_point)
 
-        self.l1 = Block(3, 64, A, residual=False)
+        self.l1 = Block(in_channels, 64, A, residual=False)
         self.l2 = Block(64, 64, A)
         self.l3 = Block(64, 64, A)
         self.l4 = Block(64, 64, A)

--- a/paddlevideo/utils/precise_bn.py
+++ b/paddlevideo/utils/precise_bn.py
@@ -66,7 +66,7 @@ def do_preciseBN(model,
 
     ind = -1
     for ind, data in enumerate(itertools.islice(data_loader, num_iters)):
-        logger.info("doing precise BN {} / {}...".format(ind + 1, num_iters))
+        logger.info("Computing precise BN {} / {}...".format(ind + 1, num_iters))
 
         if parallel:
             if use_amp:

--- a/test_tipc/common_func.sh
+++ b/test_tipc/common_func.sh
@@ -56,9 +56,10 @@ function status_check(){
     last_status=$1   # the exit code
     run_command=$2
     run_log=$3
+    model_name=$4
     if [ $last_status -eq 0 ]; then
-        echo -e "\033[33m Run successfully with command - ${run_command}!  \033[0m" | tee -a ${run_log}
+        echo -e "\033[33m Run successfully with command - ${model_name} - ${run_command}!  \033[0m" | tee -a ${run_log}
     else
-        echo -e "\033[33m Run failed with command - ${run_command}!  \033[0m" | tee -a ${run_log}
+        echo -e "\033[33m Run failed with command - ${model_name} - ${run_command}!  \033[0m" | tee -a ${run_log}
     fi
 }

--- a/test_tipc/configs/AGCN/train_amp_infer_python.txt
+++ b/test_tipc/configs/AGCN/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/agcn/agcn_fsd.yaml
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/agcn/agcn_fsd.yaml
 --use_gpu:True|False
---enable_mkldnn:False|True
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/fsd10/example_skeleton.npy

--- a/test_tipc/configs/AGCN/train_infer_python.txt
+++ b/test_tipc/configs/AGCN/train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 -o output_dir:null
--o DATASET.batch_size:null
+-o DATASET.batch_size:32
 null:null
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/AGCN/train_infer_python.txt
+++ b/test_tipc/configs/AGCN/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/agcn/agcn_fsd.yaml
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/agcn/agcn_fsd.yaml
 --use_gpu:True|False
---enable_mkldnn:False|True
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/fsd10/example_skeleton.npy

--- a/test_tipc/configs/AGCN2s/train_amp_infer_python.txt
+++ b/test_tipc/configs/AGCN2s/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/agcn2s/agcn2s_ntucs_jo
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/agcn2s/agcn2s_ntucs_joint_fsd.yaml
 --use_gpu:True|False
---enable_mkldnn:False|True
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/fsd10/example_skeleton.npy

--- a/test_tipc/configs/AGCN2s/train_infer_python.txt
+++ b/test_tipc/configs/AGCN2s/train_infer_python.txt
@@ -27,7 +27,7 @@ eval:main.py --test -c configs/recognition/agcn2s/agcn2s_ntucs_joint_fsd.yaml -o
 ===========================infer_params===========================
 -o:inference/AGCN2s
 -p:null
-norm_export:tools/export_model.py -c configs/recognition/agcn/agcn_fsd.yaml --save_name inference
+norm_export:tools/export_model.py -c configs/recognition/agcn2s/agcn2s_ntucs_joint_fsd.yaml --save_name inference
 quant_export:null
 fpgm_export:null
 distill_export:null

--- a/test_tipc/configs/AGCN2s/train_infer_python.txt
+++ b/test_tipc/configs/AGCN2s/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/agcn2s/agcn2s_ntucs_jo
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/agcn2s/agcn2s_ntucs_joint_fsd.yaml
 --use_gpu:True|False
---enable_mkldnn:False|True
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/fsd10/example_skeleton.npy

--- a/test_tipc/configs/AttentionLSTM/train_amp_infer_python.txt
+++ b/test_tipc/configs/AttentionLSTM/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/attention_lstm/attenti
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.pkl

--- a/test_tipc/configs/AttentionLSTM/train_infer_python.txt
+++ b/test_tipc/configs/AttentionLSTM/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/attention_lstm/attenti
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/attention_lstm/attention_lstm_youtube8m.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.pkl

--- a/test_tipc/configs/BMN/train_amp_infer_python.txt
+++ b/test_tipc/configs/BMN/train_amp_infer_python.txt
@@ -42,7 +42,7 @@ inference:tools/predict.py --config configs/localization/bmn.yaml
 --enable_mkldnn:False
 --cpu_threads:1|6
 --batch_size:1
---use_tensorrt:False|True
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example_feat.list

--- a/test_tipc/configs/BMN/train_infer_python.txt
+++ b/test_tipc/configs/BMN/train_infer_python.txt
@@ -42,7 +42,7 @@ inference:tools/predict.py --config configs/localization/bmn.yaml
 --enable_mkldnn:False
 --cpu_threads:1|6
 --batch_size:1
---use_tensorrt:False|True
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example_feat.list

--- a/test_tipc/configs/PP-TSM/infer_cpp.txt
+++ b/test_tipc/configs/PP-TSM/infer_cpp.txt
@@ -5,10 +5,10 @@ infer_model:./inference/ppTSM
 infer_quant:False
 inference:./deploy/cpp_infer/build/ppvideo rec
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
 --rec_batch_num:1
---use_tensorrt:False|True
+--use_tensorrt:False
 --precision:fp32|fp16
 --rec_model_dir:
 --video_dir:./deploy/cpp_infer/example_video_dir

--- a/test_tipc/configs/PP-TSM/train_amp_infer_python.txt
+++ b/test_tipc/configs/PP-TSM/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/pptsm/pptsm_k400_frame
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/pptsm/pptsm_k400_frames_uniform.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/PP-TSM/train_infer_python.txt
+++ b/test_tipc/configs/PP-TSM/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/pptsm/pptsm_k400_frame
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/pptsm/pptsm_k400_frames_uniform.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/PP-TSM/train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt.txt
+++ b/test_tipc/configs/PP-TSM/train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/pptsm/pptsm_k400_frame
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/pptsm/pptsm_k400_frames_uniform.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/PP-TSN/infer_cpp.txt
+++ b/test_tipc/configs/PP-TSN/infer_cpp.txt
@@ -5,10 +5,10 @@ infer_model:./inference/ppTSN
 infer_quant:False
 inference:./deploy/cpp_infer/build/ppvideo rec
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
 --rec_batch_num:1
---use_tensorrt:False|True
+--use_tensorrt:False
 --precision:fp32|fp16
 --rec_model_dir:
 --video_dir:./deploy/cpp_infer/example_video_dir

--- a/test_tipc/configs/PP-TSN/train_amp_infer_python.txt
+++ b/test_tipc/configs/PP-TSN/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_video
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/pptsn/pptsn_k400_videos.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/PP-TSN/train_infer_python.txt
+++ b/test_tipc/configs/PP-TSN/train_infer_python.txt
@@ -27,7 +27,7 @@ eval:main.py --test -c configs/recognition/pptsn/pptsn_k400_videos.yaml
 ===========================infer_params===========================
 -o:inference/ppTSN
 -p:null
-norm_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_videos.yaml --save_name inference
+norm_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_videos.yaml --save_name inference --override INFERENCE.num_seg=8
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -35,9 +35,9 @@ export1:null
 export2:null
 inference_dir:null
 infer_model:./data/ppTSN_k400.pdparams
-infer_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_videos.yaml
+infer_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_videos.yaml --override INFERENCE.num_seg=8
 infer_quant:False
-inference:tools/predict.py --config configs/recognition/pptsn/pptsn_k400_videos.yaml
+inference:tools/predict.py --config configs/recognition/pptsn/pptsn_k400_videos.yaml --override INFERENCE.num_seg=8
 --use_gpu:True|False
 --enable_mkldnn:False
 --cpu_threads:1|6

--- a/test_tipc/configs/PP-TSN/train_infer_python.txt
+++ b/test_tipc/configs/PP-TSN/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_video
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/pptsn/pptsn_k400_videos.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/PP-TSN/train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt.txt
+++ b/test_tipc/configs/PP-TSN/train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/pptsn/pptsn_k400_frame
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/pptsn/pptsn_k400_frames.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/STGCN/train_amp_infer_python.txt
+++ b/test_tipc/configs/STGCN/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/stgcn/stgcn_fsd.yaml
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/stgcn/stgcn_fsd.yaml
 --use_gpu:True|False
---enable_mkldnn:False|True
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/fsd10/example_skeleton.npy

--- a/test_tipc/configs/STGCN/train_infer_python.txt
+++ b/test_tipc/configs/STGCN/train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 -o output_dir:null
--o DATASET.batch_size:null
+-o DATASET.batch_size:32
 null:null
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/STGCN/train_infer_python.txt
+++ b/test_tipc/configs/STGCN/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/stgcn/stgcn_fsd.yaml
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/stgcn/stgcn_fsd.yaml
 --use_gpu:True|False
---enable_mkldnn:False|True
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/fsd10/example_skeleton.npy

--- a/test_tipc/configs/SlowFast/train_amp_infer_python.txt
+++ b/test_tipc/configs/SlowFast/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/slowfast/slowfast.yaml
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/slowfast/slowfast.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/SlowFast/train_infer_python.txt
+++ b/test_tipc/configs/SlowFast/train_infer_python.txt
@@ -6,7 +6,7 @@ Global.use_gpu:null|null
 Global.auto_cast:null
 -o epochs:2
 -o output_dir:null
--o DATASET.batch_size:null
+-o DATASET.batch_size:2
 -o MODEL.backbone.pretrained:null
 train_model_name:null
 train_infer_video_dir:null

--- a/test_tipc/configs/SlowFast/train_infer_python.txt
+++ b/test_tipc/configs/SlowFast/train_infer_python.txt
@@ -41,8 +41,8 @@ inference:tools/predict.py --config configs/recognition/slowfast/slowfast.yaml
 --use_gpu:True|False
 --enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/TSM/train_amp_infer_python.txt
+++ b/test_tipc/configs/TSM/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/tsm/tsm_k400_frames.ya
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/tsm/tsm_k400_frames.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/TSM/train_infer_python.txt
+++ b/test_tipc/configs/TSM/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/tsm/tsm_k400_frames.ya
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/tsm/tsm_k400_frames.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/TSN/train_amp_infer_python.txt
+++ b/test_tipc/configs/TSN/train_amp_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/tsn/tsn_k400_frames.ya
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/tsn/tsn_k400_frames.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/TSN/train_infer_python.txt
+++ b/test_tipc/configs/TSN/train_infer_python.txt
@@ -27,7 +27,7 @@ eval:main.py --test -c configs/recognition/tsn/tsn_k400_frames.yaml
 ===========================infer_params===========================
 -o:inference/TSN
 -p:null
-norm_export:tools/export_model.py -c configs/recognition/tsn/tsn_k400_frames.yaml --save_name inference
+norm_export:tools/export_model.py -c configs/recognition/tsn/tsn_k400_frames.yaml --save_name inference --override INFERENCE.num_seg=8
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -35,9 +35,9 @@ export1:null
 export2:null
 inference_dir:null
 infer_model:./data/TSN_k400.pdparams
-infer_export:tools/export_model.py -c configs/recognition/tsn/tsn_k400_frames.yaml
+infer_export:tools/export_model.py -c configs/recognition/tsn/tsn_k400_frames.yaml --override INFERENCE.num_seg=8
 infer_quant:False
-inference:tools/predict.py --config configs/recognition/tsn/tsn_k400_frames.yaml
+inference:tools/predict.py --config configs/recognition/tsn/tsn_k400_frames.yaml --override INFERENCE.num_seg=8
 --use_gpu:True|False
 --enable_mkldnn:False
 --cpu_threads:1|6

--- a/test_tipc/configs/TSN/train_infer_python.txt
+++ b/test_tipc/configs/TSN/train_infer_python.txt
@@ -39,10 +39,10 @@ infer_export:tools/export_model.py -c configs/recognition/tsn/tsn_k400_frames.ya
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/tsn/tsn_k400_frames.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
---use_tensorrt:False|True
+--batch_size:1
+--use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel
 --input_file:./data/example.avi

--- a/test_tipc/configs/TimeSformer/train_amp_infer_python.txt
+++ b/test_tipc/configs/TimeSformer/train_amp_infer_python.txt
@@ -39,9 +39,9 @@ infer_export:tools/export_model.py -c configs/recognition/timesformer/timesforme
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/timesformer/timesformer_k400_videos.yaml
 --use_gpu:True|False
---enable_mkldnn:True|False
+--enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
+--batch_size:1
 --use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel

--- a/test_tipc/configs/TimeSformer/train_infer_python.txt
+++ b/test_tipc/configs/TimeSformer/train_infer_python.txt
@@ -41,7 +41,7 @@ inference:tools/predict.py --config configs/recognition/timesformer/timesformer_
 --use_gpu:True|False
 --enable_mkldnn:False
 --cpu_threads:1|6
---batch_size:1|2
+--batch_size:1
 --use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel

--- a/test_tipc/configs/TokenShift/train_amp_infer_python.txt
+++ b/test_tipc/configs/TokenShift/train_amp_infer_python.txt
@@ -39,9 +39,9 @@ infer_export:tools/export_model.py -c configs/recognition/token_transformer/tokS
 infer_quant:False
 inference:tools/predict.py --config configs/recognition/token_transformer/tokShift_transformer_ucf101_256_videos.yaml
 --use_gpu:True
---enable_mkldnn:True
+--enable_mkldnn:False
 --cpu_threads:2
---batch_size:2
+--batch_size:1
 --use_tensorrt:False
 --precision:fp32|fp16
 --model_file:inference.pdmodel

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -120,9 +120,9 @@ if [ ${MODE} = "lite_train_lite_infer" ];then
         pushd ./data
         mkdir bmn_data
         cd bmn_data
-        wget -nc https://paddlemodels.bj.bcebos.com/video_detection/bmn_feat.tar.gz
+        wget -nc https://videotag.bj.bcebos.com/Data/BMN_lite/bmn_feat.tar.gz
         tar -xf bmn_feat.tar.gz
-        wget -nc https://paddlemodels.bj.bcebos.com/video_detection/activitynet_1.3_annotations.json
+        wget -nc https://videotag.bj.bcebos.com/Data/BMN_lite/activitynet_1.3_annotations.json
         wget -nc https://paddlemodels.bj.bcebos.com/video_detection/activity_net_1_3_new.json
         popd
     elif [ ${model_name} == "TokenShiftVisionTransformer" ]; then

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -63,7 +63,7 @@ if [ ${MODE} = "lite_train_lite_infer" ];then
         wget -nc https://videotag.bj.bcebos.com/Data/FSD_train_data.npy
         wget -nc https://videotag.bj.bcebos.com/Data/FSD_train_label.npy
         popd
-    elif [ ${model_name} == "AGCN2s_joint" ] || [ ${model_name} == "AGCN2s_bone" ]; then
+    elif [ ${model_name} == "AGCN2s" ]; then
         # pretrain lite train data
         pushd data/fsd10
         wget -nc https://videotag.bj.bcebos.com/Data/FSD_train_data.npy

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -171,7 +171,7 @@ function func_inference(){
                             eval $command
                             last_status=${PIPESTATUS[0]}
                             eval "cat ${_save_log_path}"
-                            status_check $last_status "${command}" "${status_log}"
+                            status_check $last_status "${command}" "${status_log}" "${model_name}"
                         done
                     done
                 done
@@ -204,7 +204,7 @@ function func_inference(){
 
                         last_status=${PIPESTATUS[0]}
                         eval "cat ${_save_log_path}"
-                        status_check $last_status "${command}" "${status_log}"
+                        status_check $last_status "${command}" "${status_log}" "${model_name}"
 
                     done
                 done
@@ -239,7 +239,8 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
             eval $export_cmd
             echo $export_cmd
             status_export=$?
-            status_check $status_export "${export_cmd}" "${status_log}"
+            status_check $status_export "${export_cmd}" "${status_log}" "${model_name}"
+            
         else
             save_infer_dir=${infer_model}
         fi
@@ -368,7 +369,7 @@ else
                 # run train
                 eval "unset CUDA_VISIBLE_DEVICES"
                 eval $cmd
-                status_check $? "${cmd}" "${status_log}"
+                status_check $? "${cmd}" "${status_log}" "${model_name}"
 
                 # set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/${train_model_name}")
                 # save norm trained models to set pretrain for pact training and fpgm training
@@ -385,7 +386,7 @@ else
                         eval_cmd="${python} ${eval_py} ${set_use_gpu} ${set_eval_params1}"
                     fi
                     eval $eval_cmd
-                    status_check $? "${eval_cmd}" "${status_log}"
+                    status_check $? "${eval_cmd}" "${status_log}" "${model_name}"
                 fi
                 # run export model
                 if [ ${run_export} != "null" ]; then
@@ -396,7 +397,7 @@ else
                     set_save_infer_key=$(func_set_params "${save_infer_key}" "${save_log}")
                     export_cmd="${python} ${run_export} ${set_export_weight} ${set_save_infer_key}"
                     eval $export_cmd
-                    status_check $? "${export_cmd}" "${status_log}"
+                    status_check $? "${export_cmd}" "${status_log}" "${model_name}"
 
                     #run inference
                     eval $env

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -35,6 +35,10 @@ def parse_args():
                         type=str,
                         default='configs/example.yaml',
                         help='config file path')
+    parser.add_argument('--override',
+                        action='append',
+                        default=[],
+                        help='config options to be overridden')
     parser.add_argument("-p",
                         "--pretrained_params",
                         default='./best.pdparams',
@@ -208,7 +212,8 @@ def get_input_spec(cfg, model_name):
 
 def main():
     args = parse_args()
-    cfg, model_name = trim_config(get_config(args.config, show=False))
+    cfg, model_name = trim_config(get_config(args.config, overrides=args.override, show=False))
+
     print(f"Building model({model_name})...")
     model = build_model(cfg.MODEL)
     assert osp.isfile(

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -34,6 +34,11 @@ def parse_args():
                         type=str,
                         default='configs/example.yaml',
                         help='config file path')
+    parser.add_argument('-o',
+                        '--override',
+                        action='append',
+                        default=[],
+                        help='config options to be overridden')
     parser.add_argument("-i", "--input_file", type=str, help="input file path")
     parser.add_argument("--time_test_file", type=str2bool, default=False, help="whether input time test file")    
     parser.add_argument("--model_file", type=str)
@@ -135,7 +140,7 @@ def main():
     """predict using paddle inference model
     """
     args = parse_args()
-    cfg = get_config(args.config, show=False)
+    cfg = get_config(args.config, overrides=args.override, show=False)
 
     model_name = cfg.model_name
     print(f"Inference model({model_name})...")

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -35,6 +35,7 @@ def parse_args():
                         default='configs/example.yaml',
                         help='config file path')
     parser.add_argument("-i", "--input_file", type=str, help="input file path")
+    parser.add_argument("--time_test_file", type=str2bool, default=False, help="whether input time test file")    
     parser.add_argument("--model_file", type=str)
     parser.add_argument("--params_file", type=str)
 
@@ -224,8 +225,7 @@ def main():
                                               'postprocess_time'
                                           ],
                                           warmup=num_warmup)
-            if args.input_file.endswith('avi') or args.input_file.endswith(
-                    'mp4'):
+            if not args.time_test_file:
                 test_video_num = 15
                 files = [args.input_file for _ in range(test_video_num)]
             else:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -270,7 +270,7 @@ class ppTSN_Inference_helper(Base_Inference_helper):
         img_mean = [0.485, 0.456, 0.406]
         img_std = [0.229, 0.224, 0.225]
         ops = [
-            VideoDecoder(),
+            VideoDecoder(backend="decord"),
             Sampler(self.num_seg,
                     self.seg_len,
                     valid_mode=True,

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -836,6 +836,7 @@ class AGCN2s_Inference_helper(Base_Inference_helper):
             input_file)
         data = np.load(input_file)
         results = {'data': data}
+        
 
         res = np.expand_dims(results['data'], axis=0).copy()
         return [res]


### PR DESCRIPTION
1. trt、mkldnn功能不需要接入，配置位置中对应的地方只设False即可
2. batch_size只跑一种
3. 修改日志规范，添加model_name参数
4. 修复AGCN2s链条跑不通
5. 修复predict修改引入的TIPC bug
6. 优化TSN/PP-TSN TIPC运行时间：减少推理阶段使用的num_seg