### PR TITLE
Fix acc for pptsm

### DIFF
--- a/paddlevideo/loader/pipelines/augmentations.py
+++ b/paddlevideo/loader/pipelines/augmentations.py
@@ -72,6 +72,10 @@ class Scale(object):
                 w, h = img.size
             else:
                 raise NotImplementedError
+            if (w <= h and w == self.short_size) or (h <= w
+                                                     and h == self.short_size):
+                resized_imgs.append(img)
+                continue
 
             if w <= h:
                 ow = self.short_size

--- a/paddlevideo/loader/pipelines/augmentations.py
+++ b/paddlevideo/loader/pipelines/augmentations.py
@@ -74,6 +74,10 @@ class Scale(object):
                 raise NotImplementedError
             if (w <= h and w == self.short_size) or (h <= w
                                                      and h == self.short_size):
+                if self.backend == 'pillow' and not isinstance(img, Image):
+                    img = Image.fromarray(img)
+                elif self.backend == 'cv2' and not isinstance(img, np.ndarray):
+                    img = np.array(img)
                 resized_imgs.append(img)
                 continue
 

--- a/paddlevideo/loader/pipelines/augmentations.py
+++ b/paddlevideo/loader/pipelines/augmentations.py
@@ -77,8 +77,6 @@ class Scale(object):
                 if self.backend == 'pillow' and not isinstance(
                         img, Image.Image):
                     img = Image.fromarray(img)
-                elif self.backend == 'cv2' and not isinstance(img, np.ndarray):
-                    img = np.array(img)
                 resized_imgs.append(img)
                 continue
 

--- a/paddlevideo/loader/pipelines/augmentations.py
+++ b/paddlevideo/loader/pipelines/augmentations.py
@@ -74,7 +74,8 @@ class Scale(object):
                 raise NotImplementedError
             if (w <= h and w == self.short_size) or (h <= w
                                                      and h == self.short_size):
-                if self.backend == 'pillow' and not isinstance(img, Image):
+                if self.backend == 'pillow' and not isinstance(
+                        img, Image.Image):
                     img = Image.fromarray(img)
                 elif self.backend == 'cv2' and not isinstance(img, np.ndarray):
                     img = np.array(img)


### PR DESCRIPTION
1. 修复数据增强类`Scale`的判断逻辑BUG导致部分模型掉点的问题。
该问题由VideoSwinTransformer的复现PR引入：https://github.com/PaddlePaddle/PaddleVideo/commit/9a30a8a252600c579bbec2318353b6b4c5e1d35a#diff-03b1a6aedec7270825bd8d7470779e13be9c3579b15eb90aa1e720fd8a17ed97L62-L67
修复前：如果w或h与target_size相等，则同样会对图片进行缩放再放入`resized_images`，`ppTSM_k400_uniform.pdparams`的精度为0.7386
修复后：如果w或h与target_size相等，则直接放入`resized_images`，`ppTSM_k400_uniform.pdparams`的精度为0.7438