### PR TITLE
fix benchmark

### DIFF
--- a/test_tipc/configs/BMN/train_infer_python.txt
+++ b/test_tipc/configs/BMN/train_infer_python.txt
@@ -56,5 +56,5 @@ batch_size:8
 fp_items:fp32|fp16
 epoch:1
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
-flags:FLAGS_conv_workspace_size_limit=800
+flags:FLAGS_conv_workspace_size_limit=800;FLAGS_cudnn_exhaustive_search=1
 max-iters:100

--- a/test_tipc/configs/TimeSformer/train_infer_python.txt
+++ b/test_tipc/configs/TimeSformer/train_infer_python.txt
@@ -56,5 +56,5 @@ batch_size:1|14
 fp_items:fp32|fp16
 epoch:1
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
-flags:FLAGS_conv_workspace_size_limit=800
+flags:FLAGS_conv_workspace_size_limit=800;FLAGS_cudnn_exhaustive_search=1 
 max-iters:800


### PR DESCRIPTION
fix benchmark
修复BMN，TimeSformer  由于缺少FLAGS_cudnn_exhaustive_search=1 引起的性能下降问题