### PR TITLE
[TIPC]Support @to_static training for BMN

### DIFF
--- a/paddlevideo/tasks/train.py
+++ b/paddlevideo/tasks/train.py
@@ -101,6 +101,12 @@ def train_model(cfg,
     # 1. Construct model
     model = build_model(cfg.MODEL)
 
+    if cfg.get('to_static', False):
+        specs = None
+        model = paddle.jit.to_static(model, input_spec=specs)
+        logger.info(
+            "Successfully to apply @to_static with specs: {}".format(specs))
+
     # 2. Construct dataset and dataloader for training and evaluation
     train_dataset = build_dataset((cfg.DATASET.train, cfg.PIPELINE.train))
     train_dataloader_setting = dict(batch_size=batch_size,

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -74,7 +74,20 @@ FILENAME=$new_filename
 # MODE must be one of ['benchmark_train']
 MODE=$2
 PARAMS=$3
-# bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train dynamic_bs8_null_DP_N1C1
+REST_ARGS=$4
+# bash test_tipc/benchmark_train.sh /workspace/PaddleVideo/test_tipc/configs/BMN/train_infer_python.txt benchmark_train to_static
+
+to_static="d2sF"
+# parse "to_static" options and modify trainer into "to_static_trainer"
+if [ $REST_ARGS = "to_static" ] || [ $PARAMS = "to_static" ] ;then
+   to_static="d2sT"
+   sed -i 's/trainer:norm_train/trainer:to_static_train/g' $FILENAME
+   # clear PARAM contents
+   if [ $PARAMS = "to_static" ] ;then
+    PARAMS=""
+   fi
+fi
+
 IFS=$'\n'
 # parser params from train_benchmark.txt
 dataline=`cat $FILENAME`
@@ -191,7 +204,7 @@ for batch_size in ${batch_size_list[*]}; do
             if [ ${#gpu_id} -le 1 ];then
                 log_path="$SAVE_LOG/profiling_log"
                 mkdir -p $log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_profiling"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_profiling"
                 func_sed_params "$FILENAME" "${line_gpuid}" "0"  # sed used gpu_id
                 # set profile_option params
                 tmp=`sed -i "${line_profile}s/.*/${profile_option}/" "${FILENAME}"`
@@ -214,8 +227,8 @@ for batch_size in ${batch_size_list[*]}; do
                 speed_log_path="$SAVE_LOG/index"
                 mkdir -p $log_path
                 mkdir -p $speed_log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_log"
-                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_speed"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_log"
+                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_speed"
                 func_sed_params "$FILENAME" "${line_profile}" "null"  # sed profile_id as null
 
                 cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} benchmark_train > ${log_path}/${log_name} 2>&1 "
@@ -250,8 +263,8 @@ for batch_size in ${batch_size_list[*]}; do
                 speed_log_path="$SAVE_LOG/index"
                 mkdir -p $log_path
                 mkdir -p $speed_log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_log"
-                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_speed"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_log"
+                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_speed"
                 func_sed_params "$FILENAME" "${line_gpuid}" "$gpu_id"  # sed used gpu_id
                 func_sed_params "$FILENAME" "${line_profile}" "null"  # sed --profile_option as null
 

--- a/test_tipc/configs/BMN/train_infer_python.txt
+++ b/test_tipc/configs/BMN/train_infer_python.txt
@@ -18,7 +18,7 @@ pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
-null:null
+to_static_train:-o to_static=True
 ##
 ===========================eval_params===========================
 eval:main.py --test -c configs/localization/bmn.yaml

--- a/test_tipc/configs/PP-TSM/train_infer_python.txt
+++ b/test_tipc/configs/PP-TSM/train_infer_python.txt
@@ -18,7 +18,7 @@ pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
-to_static_train:-o to_static=True
+null:null
 ##
 ===========================eval_params===========================
 eval:main.py --test -c configs/recognition/pptsm/pptsm_k400_frames_uniform.yaml

--- a/test_tipc/configs/PP-TSM/train_infer_python.txt
+++ b/test_tipc/configs/PP-TSM/train_infer_python.txt
@@ -18,7 +18,7 @@ pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
-null:null
+to_static_train:-o to_static=True
 ##
 ===========================eval_params===========================
 eval:main.py --test -c configs/recognition/pptsm/pptsm_k400_frames_uniform.yaml

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -43,8 +43,8 @@ distill_key=$(func_parser_key "${lines[18]}")
 distill_trainer=$(func_parser_value "${lines[18]}")
 amp_key=$(func_parser_key "${lines[19]}")
 amp_trainer=$(func_parser_value "${lines[19]}")
-trainer_key2=$(func_parser_key "${lines[20]}")
-trainer_value2=$(func_parser_value "${lines[20]}")
+to_static_key=$(func_parser_key "${lines[20]}")
+to_static_trainer=$(func_parser_value "${lines[20]}")
 
 eval_py=$(func_parser_value "${lines[23]}")
 eval_key1=$(func_parser_key "${lines[24]}")
@@ -301,9 +301,12 @@ else
                 elif [ ${trainer} = ${amp_key} ]; then
                     run_train=${amp_trainer}
                     run_export=${norm_export}
-                elif [[ ${trainer} = ${trainer_key2} ]]; then
-                    run_train=${trainer_value2}
-                    run_export=${export_value2}
+                # In case of @to_static, we re-used norm_traier,
+                # but append "-o Global.to_static=True" for config
+                # to trigger "apply_to_static" logic in 'engine.py'
+                elif [ ${trainer} = "${to_static_key}" ]; then
+                    run_train="${norm_trainer}  ${to_static_trainer}"
+                    run_export=${norm_export}
                 else
                     run_train=${norm_trainer}
                     run_export=${norm_export}

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -302,8 +302,8 @@ else
                     run_train=${amp_trainer}
                     run_export=${norm_export}
                 # In case of @to_static, we re-used norm_traier,
-                # but append "-o Global.to_static=True" for config
-                # to trigger "apply_to_static" logic in 'engine.py'
+                # but append "-o to_static=True" for config
+                # to trigger "to_static" logic in 'train.py'
                 elif [ ${trainer} = "${to_static_key}" ]; then
                     run_train="${norm_trainer}  ${to_static_trainer}"
                     run_export=${norm_export}


### PR DESCRIPTION
此 PR 基于新Benchmark规范实现了 @to_static 动转静训练监控机制，在现有的功能上，为兼容性升级。

### **1. 使用方法**
在动态图训练的基础上，开启动转静训练的方法如下：
- 配置参数名：to_static（不能拼写错误，大小写敏感）
```
bash test_tipc/benchmark_train.sh /workspace/PaddleVideo/test_tipc/configs/BMN/train_infer_python.txt benchmark_train to_static
```

### **2. 验证日志**
此PR在4卡条件下对fp16和fp32模型进行了动转静验证
可以根据日志中的 Successfully to apply @to_static with specs XX 来判断动转静是否生效，日志如下：
```
I0913 08:25:16.730999 12214 nccl_context.cc:83] init nccl context nranks: 4 local rank: 0 gpu id: 0 ring id: 0
W0913 08:25:17.990571 12214 gpu_resources.cc:61] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 11.2, Runtime API Version: 10.1
W0913 08:25:17.999856 12214 gpu_resources.cc:91] device: 0, cuDNN Version: 7.6.
[09/13 08:25:21] cfg.to_static: True
[09/13 08:25:21] Successfully to apply @to_static with specs: None
[09/13 08:25:21] train subset video numbers: 500
[09/13 08:25:21] Training in fp32 mode.
[09/13 08:25:27] [35mepoch:[  1/1  ][0m [95mtrain step:0   [0m [92mloss: 2.51266 lr: 0.001000[0m [92mbatch_cost: 5.85036 sec,[0m [92mreader_cost: 1.02560 sec,[0m ips: 1.36744 instance/sec, eta: 0:01:22
[09/13 08:25:27] epoch:[  1/1  ] [95mtrain step:1   [0m [92mloss: 2.69863 lr: 0.001000[0m [92mbatch_cost: 0.17376 sec,[0m [92mreader_cost: 0.00254 sec,[0m ips: 46.03984 instance/sec, eta: 0:00:39
[09/13 08:25:27] epoch:[  1/1  ] [95mtrain step:2   [0m [92mloss: 2.70439 lr: 0.001000[0m [92mbatch_cost: 0.16106 sec,[0m [92mreader_cost: 0.00055 sec,[0m ips: 49.67053 instance/sec, eta: 0:00:25
[09/13 08:25:27] epoch:[  1/1  ] [95mtrain step:3   [0m [92mloss: 2.34407 lr: 0.001000[0m [92mbatch_cost: 0.16116 sec,[0m [92mreader_cost: 0.00058 sec,[0m ips: 49.63908 instance/sec, eta: 0:00:17
[09/13 08:25:28] epoch:[  1/1  ] [95mtrain step:4   [0m [92mloss: 2.31874 lr: 0.001000[0m [92mbatch_cost: 0.16154 sec,[0m [92mreader_cost: 0.00056 sec,[0m ips: 49.52391 instance/sec, eta: 0:00:13
[09/13 08:25:28] epoch:[  1/1  ] [95mtrain step:5   [0m [92mloss: 2.25306 lr: 0.001000[0m [92mbatch_cost: 0.16545 sec,[0m [92mreader_cost: 0.00057 sec,[0m ips: 48.35239 instance/sec, eta: 0:00:10
[09/13 08:25:28] epoch:[  1/1  ] [95mtrain step:6   [0m [92mloss: 1.97160 lr: 0.001000[0m [92mbatch_cost: 0.16127 sec,[0m [92mreader_cost: 0.00060 sec,[0m ips: 49.60665 instance/sec, eta: 0:00:08
[09/13 08:25:28] epoch:[  1/1  ] [95mtrain step:7   [0m [92mloss: 1.99555 lr: 0.001000[0m [92mbatch_cost: 0.16151 sec,[0m [92mreader_cost: 0.00066 sec,[0m ips: 49.53100 instance/sec, eta: 0:00:06
[09/13 08:25:28] epoch:[  1/1  ] [95mtrain step:8   [0m [92mloss: 2.51723 lr: 0.001000[0m [92mbatch_cost: 0.16478 sec,[0m [92mreader_cost: 0.00060 sec,[0m ips: 48.54863 instance/sec, eta: 0:00:05
[09/13 08:25:28] epoch:[  1/1  ] [95mtrain step:9   [0m [92mloss: 2.05837 lr: 0.001000[0m [92mbatch_cost: 0.16227 sec,[0m [92mreader_cost: 0.00059 sec,[0m ips: 49.29988 instance/sec, eta: 0:00:04
[09/13 08:25:29] epoch:[  1/1  ] [95mtrain step:10  [0m [92mloss: 1.79087 lr: 0.001000[0m [92mbatch_cost: 0.16226 sec,[0m [92mreader_cost: 0.00062 sec,[0m ips: 49.30285 instance/sec, eta: 0:00:03
[09/13 08:25:29] epoch:[  1/1  ] [95mtrain step:11  [0m [92mloss: 2.19402 lr: 0.001000[0m [92mbatch_cost: 0.16255 sec,[0m [92mreader_cost: 0.00049 sec,[0m ips: 49.21441 instance/sec, eta: 0:00:02
[09/13 08:25:29] epoch:[  1/1  ] [95mtrain step:12  [0m [92mloss: 1.94314 lr: 0.001000[0m [92mbatch_cost: 0.16094 sec,[0m [92mreader_cost: 0.00061 sec,[0m ips: 49.70740 instance/sec, eta: 0:00:01
[09/13 08:25:29] epoch:[  1/1  ] [95mtrain step:13  [0m [92mloss: 2.11949 lr: 0.001000[0m [92mbatch_cost: 0.16182 sec,[0m [92mreader_cost: 0.00059 sec,[0m ips: 49.43876 instance/sec, eta: 0:00:01
[09/13 08:25:29] epoch:[  1/1  ] [95mtrain step:14  [0m [92mloss: 2.05102 lr: 0.001000[0m [92mbatch_cost: 0.16326 sec,[0m [92mreader_cost: 0.00080 sec,[0m ips: 49.00253 instance/sec, eta: 0:00:00
[09/13 08:25:29] [31mEND epoch:1  [0m [95mtrain[0m [92mloss_avg: 2.23152 [0m [92mavg_batch_cost: 0.16326 sec,[0m [92mavg_reader_cost: 0.00080 sec,[0m [92mbatch_cost_sum: 8.13400 sec,[0m avg_ips: 14.75288 instance/sec.
[09/13 08:25:29] training BMN finished
[33m Run successfully with command - BMN - python -B -m paddle.distributed.launch --gpus="0,1,2,3" main.py  -c configs/localization/bmn.yaml --seed 1234 --max_iters=100 -o log_interval=1  -o to_static=True     -o output_dir=./test_tipc/output/BMN/benchmark_train/to_static_train_gpus_0,1,2,3_autocast_fp32_nodes_1 -o epochs=1   -o DATASET.batch_size=8     > ./test_tipc/output/BMN/benchmark_train/train.log 2>&1!  [0m
```

### **3 方案介绍**
在benchmark_train.sh增加了REST_ARGS参数，来捕获动转静to_static参数。在具体的train_infer_python.txt中，修改第21行参数新增动转静参数trainer `to_static_train:-o to_static=True`
此处会复用trainer:norm_train的配置，在其后追加-o to_static=True 来实现开启动转静训练，以保证动转静训练和动态图训练的基本配置参数是对齐的。
可以参考PaddleClas仓库的类似PR：https://github.com/PaddlePaddle/PaddleClas/pull/1756

### **4 PPTSM测试日志**
#### 4.1 单卡
测试命令：`python main.py  --validate -c configs/recognition/pptsm/v2/pptsm_lcnet_k400_16frames_uniform.yaml -o to_static=True`
部分日志：
```
[09/19 06:12:27] Successfully to apply @to_static with specs: None
[09/19 06:12:27] Training in fp32 mode.
[09/19 06:12:34] epoch:[  1/120] train step:0    loss: 6.73109 lr: 0.005000 top1: 0.00000 top5: 0.00000 batch_cost: 6.66994 sec, reader_cost: 2.35108 sec, ips: 2.39882 instance/sec, eta: 4 days, 10:43:02
[09/19 06:12:38] epoch:[  1/120] train step:10   loss: 0.64441 lr: 0.005010 top1: 0.68359 top5: 1.00000 batch_cost: 0.34460 sec, reader_cost: 0.00044 sec, ips: 46.43097 instance/sec, eta: 14:49:41
[09/19 06:12:41] epoch:[  1/120] train step:20   loss: 1.77272 lr: 0.005020 top1: 0.31850 top5: 1.00000 batch_cost: 0.35524 sec, reader_cost: 0.01112 sec, ips: 45.04014 instance/sec, eta: 10:25:10
[09/19 06:12:45] epoch:[  1/120] train step:30   loss: 0.66177 lr: 0.005030 top1: 0.62500 top5: 1.00000 batch_cost: 0.35329 sec, reader_cost: 0.00018 sec, ips: 45.28862 instance/sec, eta: 8:51:52
[09/19 06:12:48] epoch:[  1/120] train step:40   loss: 0.46200 lr: 0.005040 top1: 0.93743 top5: 1.00000 batch_cost: 0.35532 sec, reader_cost: 0.01115 sec, ips: 45.02938 instance/sec, eta: 8:07:50
[09/19 06:12:52] epoch:[  1/120] train step:50   loss: 0.41329 lr: 0.005050 top1: 0.88572 top5: 1.00000 batch_cost: 0.34523 sec, reader_cost: 0.00028 sec, ips: 46.34539 instance/sec, eta: 7:41:58
[09/19 06:12:56] epoch:[  1/120] train step:60   loss: 0.53469 lr: 0.005060 top1: 0.90301 top5: 1.00000 batch_cost: 0.34418 sec, reader_cost: 0.00046 sec, ips: 46.48793 instance/sec, eta: 7:26:51
[09/19 06:13:00] epoch:[  1/120] train step:70   loss: 0.53371 lr: 0.005070 top1: 0.82604 top5: 1.00000 batch_cost: 0.34522 sec, reader_cost: 0.00027 sec, ips: 46.34734 instance/sec, eta: 7:14:23
[09/19 06:13:03] epoch:[  1/120] train step:80   loss: 0.77505 lr: 0.005080 top1: 0.62344 top5: 1.00000 batch_cost: 0.35566 sec, reader_cost: 0.01119 sec, ips: 44.98712 instance/sec, eta: 7:06:40
[09/19 06:13:07] epoch:[  1/120] train step:90   loss: 0.59047 lr: 0.005091 top1: 0.81889 top5: 1.00000 batch_cost: 0.34356 sec, reader_cost: 0.00029 sec, ips: 46.57133 instance/sec, eta: 6:59:05
[09/19 06:13:11] epoch:[  1/120] train step:100  loss: 0.34422 lr: 0.005101 top1: 0.81238 top5: 1.00000 batch_cost: 0.34595 sec, reader_cost: 0.00023 sec, ips: 46.24896 instance/sec, eta: 6:54:26
[09/19 06:13:15] epoch:[  1/120] train step:110  loss: 0.35365 lr: 0.005111 top1: 0.79929 top5: 1.00000 batch_cost: 0.35506 sec, reader_cost: 0.00015 sec, ips: 45.06307 instance/sec, eta: 6:49:11
[09/19 06:13:19] epoch:[  1/120] train step:120  loss: 0.62610 lr: 0.005121 top1: 0.73840 top5: 1.00000 batch_cost: 0.35256 sec, reader_cost: 0.00859 sec, ips: 45.38299 instance/sec, eta: 6:45:54
[09/19 06:13:22] epoch:[  1/120] train step:130  loss: 0.31510 lr: 0.005131 top1: 0.86782 top5: 1.00000 batch_cost: 0.34472 sec, reader_cost: 0.00021 sec, ips: 46.41385 instance/sec, eta: 6:42:21
[09/19 06:13:26] epoch:[  1/120] train step:140  loss: 0.31352 lr: 0.005141 top1: 0.86723 top5: 1.00000 batch_cost: 0.35597 sec, reader_cost: 0.01072 sec, ips: 44.94732 instance/sec, eta: 6:40:04
[09/19 06:13:30] epoch:[  1/120] train step:150  loss: 0.14927 lr: 0.005151 top1: 0.99926 top5: 1.00000 batch_cost: 0.34471 sec, reader_cost: 0.00018 sec, ips: 46.41607 instance/sec, eta: 6:37:21
[09/19 06:13:34] epoch:[  1/120] train step:160  loss: 0.21829 lr: 0.005161 top1: 0.95664 top5: 1.00000 batch_cost: 0.34361 sec, reader_cost: 0.00018 sec, ips: 46.56503 instance/sec, eta: 6:34:52
[09/19 06:13:38] epoch:[  1/120] train step:170  loss: 0.04707 lr: 0.005171 top1: 0.99380 top5: 1.00000 batch_cost: 0.34406 sec, reader_cost: 0.00034 sec, ips: 46.50381 instance/sec, eta: 6:33:15
[09/19 06:13:41] epoch:[  1/120] train step:180  loss: 0.12564 lr: 0.005181 top1: 0.99290 top5: 1.00000 batch_cost: 0.35184 sec, reader_cost: 0.00055 sec, ips: 45.47577 instance/sec, eta: 6:31:46
[09/19 06:13:45] epoch:[  1/120] train step:190  loss: 0.57605 lr: 0.005191 top1: 0.68750 top5: 1.00000 batch_cost: 0.34382 sec, reader_cost: 0.00019 sec, ips: 46.53532 instance/sec, eta: 6:30:21
[09/19 06:13:49] epoch:[  1/120] train step:200  loss: 0.31492 lr: 0.005201 top1: 0.95305 top5: 1.00000 batch_cost: 0.35466 sec, reader_cost: 0.01109 sec, ips: 45.11378 instance/sec, eta: 6:29:17
[09/19 06:13:53] epoch:[  1/120] train step:210  loss: 0.33145 lr: 0.005211 top1: 0.92668 top5: 1.00000 batch_cost: 0.34403 sec, reader_cost: 0.00025 sec, ips: 46.50733 instance/sec, eta: 6:27:40
[09/19 06:13:57] epoch:[  1/120] train step:220  loss: 0.06141 lr: 0.005221 top1: 0.99696 top5: 1.00000 batch_cost: 0.34443 sec, reader_cost: 0.00063 sec, ips: 46.45302 instance/sec, eta: 6:26:52
[09/19 06:14:00] epoch:[  1/120] train step:230  loss: 1.10697 lr: 0.005231 top1: 0.68777 top5: 1.00000 batch_cost: 0.34355 sec, reader_cost: 0.00019 sec, ips: 46.57223 instance/sec, eta: 6:25:26
```

#### 4.1 多卡
测试命令：`python -B -m paddle.distributed.launch --gpus="0,1,2,3"  --log_dir=log_pptsm  main.py  --validate -c configs/recognition/pptsm/v2/pptsm_lcnet_k400_16frames_uniform.yaml -o to_static=True`
部分日志：
```
[09/19 03:41:09] Successfully to apply @to_static with specs: None
[09/19 03:41:09] Training in fp32 mode.
[09/19 03:41:16] [35mepoch:[  1/120][0m [95mtrain step:0   [0m [92mloss: 6.73109 lr: 0.005000 top1: 0.00000 top5: 0.00000[0m [92mbatch_cost: 6.85268 sec,[0m [92mreader_cost: 2.28505 sec,[0m ips: 2.33485 instance/sec, eta: 1 day, 3:24:32
[09/19 03:41:20] epoch:[  1/120] [95mtrain step:10  [0m [92mloss: 0.68812 lr: 0.005040 top1: 0.56250 top5: 1.00000[0m [92mbatch_cost: 0.39994 sec,[0m [92mreader_cost: 0.00819 sec,[0m ips: 40.00633 instance/sec, eta: 4:00:06
[09/19 03:41:25] epoch:[  1/120] [95mtrain step:20  [0m [92mloss: 0.45856 lr: 0.005080 top1: 0.67549 top5: 1.00000[0m [92mbatch_cost: 0.42013 sec,[0m [92mreader_cost: 0.01070 sec,[0m ips: 38.08362 instance/sec, eta: 2:52:55
[09/19 03:41:29] epoch:[  1/120] [95mtrain step:30  [0m [92mloss: 0.66852 lr: 0.005121 top1: 0.56250 top5: 1.00000[0m [92mbatch_cost: 0.40848 sec,[0m [92mreader_cost: 0.02049 sec,[0m ips: 39.17002 instance/sec, eta: 2:28:31
[09/19 03:41:33] epoch:[  1/120] [95mtrain step:40  [0m [92mloss: 1.34419 lr: 0.005161 top1: 0.56250 top5: 1.00000[0m [92mbatch_cost: 0.39555 sec,[0m [92mreader_cost: 0.00849 sec,[0m ips: 40.44974 instance/sec, eta: 2:15:25
[09/19 03:41:37] epoch:[  1/120] [95mtrain step:50  [0m [92mloss: 0.39303 lr: 0.005201 top1: 0.89866 top5: 1.00000[0m [92mbatch_cost: 0.41825 sec,[0m [92mreader_cost: 0.02099 sec,[0m ips: 38.25508 instance/sec, eta: 2:07:56
[09/19 03:41:41] epoch:[  1/120] [95mtrain step:60  [0m [92mloss: 0.90995 lr: 0.005241 top1: 0.59051 top5: 1.00000[0m [92mbatch_cost: 0.39418 sec,[0m [92mreader_cost: 0.00022 sec,[0m ips: 40.59059 instance/sec, eta: 2:02:58
[09/19 03:41:45] epoch:[  1/120] [95mtrain step:70  [0m [92mloss: 0.38953 lr: 0.005282 top1: 0.83958 top5: 1.00000[0m [92mbatch_cost: 0.42734 sec,[0m [92mreader_cost: 0.01107 sec,[0m ips: 37.44127 instance/sec, eta: 1:59:20
[09/19 03:41:49] epoch:[  1/120] [95mtrain step:80  [0m [92mloss: 0.53149 lr: 0.005322 top1: 0.77031 top5: 1.00000[0m [92mbatch_cost: 0.40983 sec,[0m [92mreader_cost: 0.01961 sec,[0m ips: 39.04096 instance/sec, eta: 1:56:36
[09/19 03:41:53] epoch:[  1/120] [95mtrain step:90  [0m [92mloss: 0.49095 lr: 0.005362 top1: 0.76278 top5: 1.00000[0m [92mbatch_cost: 0.42288 sec,[0m [92mreader_cost: 0.02049 sec,[0m ips: 37.83550 instance/sec, eta: 1:54:25
[09/19 03:41:57] epoch:[  1/120] [95mtrain step:100 [0m [92mloss: 0.24645 lr: 0.005402 top1: 0.93734 top5: 1.00000[0m [92mbatch_cost: 0.41056 sec,[0m [92mreader_cost: 0.02087 sec,[0m ips: 38.97081 instance/sec, eta: 1:52:51
[09/19 03:42:01] epoch:[  1/120] [95mtrain step:110 [0m [92mloss: 0.21143 lr: 0.005443 top1: 0.86620 top5: 1.00000[0m [92mbatch_cost: 0.41187 sec,[0m [92mreader_cost: 0.02083 sec,[0m ips: 38.84698 instance/sec, eta: 1:51:22
[09/19 03:42:05] [31mEND epoch:1  [0m [95mtrain[0m [92mloss_avg: 0.63308  top1_avg: 0.73512 top5_avg: 0.99167[0m [92mavg_batch_cost: 0.39623 sec,[0m [92mavg_reader_cost: 0.00019 sec,[0m [92mbatch_cost_sum: 55.50963 sec,[0m avg_ips: 34.58860 instance/sec.
[09/19 03:42:08] [35mepoch:[  1/120][0m [95mval step:0   [0m [92mloss: 0.34878 top1: 0.96875 top5: 0.90625[0m [92mbatch_cost: 3.39598 sec,[0m [92mreader_cost: 0.00000 sec,[0m ips: 4.71145 instance/sec. 
[09/19 03:42:10] [31mEND epoch:1  [0m [95mval[0m [92mloss_avg: 0.26159 top1_avg: 0.97656 top5_avg: 0.92969[0m [92mavg_batch_cost: 1.48478 sec,[0m [92mavg_reader_cost: 0.00000 sec,[0m [92mbatch_cost_sum: 5.15548 sec,[0m avg_ips: 12.41397 instance/sec.
[09/19 03:42:11] Already save the best model (top1 acc)0.9765
[09/19 03:42:13] [35mepoch:[  2/120][0m [95mtrain step:0   [0m [92mloss: 0.42128 lr: 0.005483 top1: 0.83977 top5: 1.00000[0m [92mbatch_cost: 2.49365 sec,[0m [92mreader_cost: 2.12207 sec,[0m ips: 6.41628 instance/sec, eta: 0:04:54
[09/19 03:42:18] epoch:[  2/120] [95mtrain step:10  [0m [92mloss: 0.06712 lr: 0.005523 top1: 0.99997 top5: 1.00000[0m [92mbatch_cost: 0.42491 sec,[0m [92mreader_cost: 0.00022 sec,[0m ips: 37.65477 instance/sec, eta: 0:12:33
[09/19 03:42:22] epoch:[  2/120] [95mtrain step:20  [0m [92mloss: 0.54816 lr: 0.005563 top1: 0.83804 top5: 1.00000[0m [92mbatch_cost: 0.55936 sec,[0m [92mreader_cost: 0.00041 sec,[0m ips: 28.60430 instance/sec, eta: 0:19:21
[09/19 03:42:27] epoch:[  2/120] [95mtrain step:30  [0m [92mloss: 0.09924 lr: 0.005604 top1: 0.93749 top5: 1.00000[0m [92mbatch_cost: 0.41029 sec,[0m [92mreader_cost: 0.00025 sec,[0m ips: 38.99685 instance/sec, eta: 0:25:01
[09/19 03:42:31] epoch:[  2/120] [95mtrain step:40  [0m [92mloss: 0.20131 lr: 0.005644 top1: 0.96465 top5: 1.00000[0m [92mbatch_cost: 0.51695 sec,[0m [92mreader_cost: 0.02041 sec,[0m ips: 30.95099 instance/sec, eta: 0:29:55
[09/19 03:42:35] epoch:[  2/120] [95mtrain step:50  [0m [92mloss: 0.05930 lr: 0.005684 top1: 0.99996 top5: 1.00000[0m [92mbatch_cost: 0.39929 sec,[0m [92mreader_cost: 0.01245 sec,[0m ips: 40.07160 instance/sec, eta: 0:34:02
[09/19 03:42:40] epoch:[  2/120] [95mtrain step:60  [0m [92mloss: 0.24338 lr: 0.005724 top1: 0.98475 top5: 1.00000[0m [92mbatch_cost: 0.55321 sec,[0m [92mreader_cost: 0.00051 sec,[0m ips: 28.92196 instance/sec, eta: 0:37:58
[09/19 03:42:44] epoch:[  2/120] [95mtrain step:70  [0m [92mloss: 0.07848 lr: 0.005765 top1: 0.99339 top5: 1.00000[0m [92mbatch_cost: 0.40323 sec,[0m [92mreader_cost: 0.01227 sec,[0m ips: 39.67969 instance/sec, eta: 0:41:13
[09/19 03:42:48] epoch:[  2/120] [95mtrain step:80  [0m [92mloss: 0.64006 lr: 0.005805 top1: 0.79736 top5: 1.00000[0m [92mbatch_cost: 0.54332 sec,[0m [92mreader_cost: 0.02141 sec,[0m ips: 29.44884 instance/sec, eta: 0:44:24
[09/19 03:42:52] epoch:[  2/120] [95mtrain step:90  [0m [92mloss: 0.07835 lr: 0.005845 top1: 0.99810 top5: 1.00000[0m [92mbatch_cost: 0.41555 sec,[0m [92mreader_cost: 0.00023 sec,[0m ips: 38.50348 instance/sec, eta: 0:46:56
[09/19 03:42:57] epoch:[  2/120] [95mtrain step:100 [0m [92mloss: 0.04917 lr: 0.005885 top1: 0.99844 top5: 1.00000[0m [92mbatch_cost: 0.55672 sec,[0m [92mreader_cost: 0.00051 sec,[0m ips: 28.73970 instance/sec, eta: 0:49:30
[09/19 03:43:01] epoch:[  2/120] [95mtrain step:110 [0m [92mloss: 0.13452 lr: 0.005926 top1: 0.97614 top5: 1.00000[0m [92mbatch_cost: 0.39687 sec,[0m [92mreader_cost: 0.00024 sec,[0m ips: 40.31545 instance/sec, eta: 0:51:44
[09/19 03:43:05] [31mEND epoch:2  [0m [95mtrain[0m [92mloss_avg: 0.24357  top1_avg: 0.91976 top5_avg: 1.00000[0m [92mavg_batch_cost: 0.39589 sec,[0m [92mavg_reader_cost: 0.00015 sec,[0m [92mbatch_cost_sum: 54.40227 sec,[0m avg_ips: 35.29265 instance/sec.
[09/19 03:43:07] [35mepoch:[  2/120][0m [95mval step:0   [0m [92mloss: 0.03184 top1: 1.00000 top5: 1.00000[0m [92mbatch_cost: 1.56503 sec,[0m [92mreader_cost: 0.00000 sec,[0m ips: 10.22345 instance/sec. 
[09/19 03:43:07] [31mEND epoch:2  [0m [95mval[0m [92mloss_avg: 0.02480 top1_avg: 1.00000 top5_avg: 1.00000[0m [92mavg_batch_cost: 0.01925 sec,[0m [92mavg_reader_cost: 0.00000 sec,[0m [92mbatch_cost_sum: 1.85256 sec,[0m avg_ips: 34.54671 instance/sec.
[09/19 03:43:07] Already save the best model (top1 acc)1.0
```
