### PR TITLE
[TIPC] add xpu and npu scripts, test=develop

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,35 +24,36 @@ from paddlevideo.utils import get_config, get_dist_info
 
 def parse_args():
     parser = argparse.ArgumentParser("PaddleVideo train script")
-    parser.add_argument('-c',
-                        '--config',
-                        type=str,
-                        default='configs/example.yaml',
-                        help='config file path')
-    parser.add_argument('-o',
-                        '--override',
-                        action='append',
-                        default=[],
-                        help='config options to be overridden')
-    parser.add_argument('--test',
-                        action='store_true',
-                        help='whether to test a model')
-    parser.add_argument('--train_dali',
-                        action='store_true',
-                        help='whether to use dali to speed up training')
-    parser.add_argument('--multigrid',
-                        action='store_true',
-                        help='whether to use multigrid training')
-    parser.add_argument('-w',
-                        '--weights',
-                        type=str,
-                        help='weights for finetuning or testing')
-    parser.add_argument('--fleet',
-                        action='store_true',
-                        help='whether to use fleet run distributed training')
-    parser.add_argument('--amp',
-                        action='store_true',
-                        help='whether to open amp training.')
+    parser.add_argument(
+        '-c',
+        '--config',
+        type=str,
+        default='configs/example.yaml',
+        help='config file path')
+    parser.add_argument(
+        '-o',
+        '--override',
+        action='append',
+        default=[],
+        help='config options to be overridden')
+    parser.add_argument(
+        '--test', action='store_true', help='whether to test a model')
+    parser.add_argument(
+        '--train_dali',
+        action='store_true',
+        help='whether to use dali to speed up training')
+    parser.add_argument(
+        '--multigrid',
+        action='store_true',
+        help='whether to use multigrid training')
+    parser.add_argument(
+        '-w', '--weights', type=str, help='weights for finetuning or testing')
+    parser.add_argument(
+        '--fleet',
+        action='store_true',
+        help='whether to use fleet run distributed training')
+    parser.add_argument(
+        '--amp', action='store_true', help='whether to open amp training.')
     parser.add_argument(
         '--amp_level',
         type=str,
@@ -79,10 +80,6 @@ def parse_args():
         default=None,
         help='The option of profiler, which should be in format '
         '\"key1=value1;key2=value2;key3=value3\".')
-    parser.add_argument('--use_npu',
-                        type=bool,
-                        default=False,
-                        help='whether use npu.')
 
     args = parser.parse_args()
     return args
@@ -91,6 +88,12 @@ def parse_args():
 def main():
     args = parse_args()
     cfg = get_config(args.config, overrides=args.override)
+
+    # enable to use npu if paddle is built with npu
+    if paddle.device.is_compiled_with_npu():
+        cfg.__setattr__("use_npu", True)
+    elif paddle.device.is_compiled_with_xpu():
+        cfg.__setattr__("use_xpu", True)
 
     # set seed if specified
     seed = args.seed
@@ -120,19 +123,19 @@ def main():
     elif args.train_dali:
         train_dali(cfg, weights=args.weights, parallel=parallel)
     elif args.multigrid:
-        train_model_multigrid(cfg,
-                              world_size=world_size,
-                              validate=args.validate)
+        train_model_multigrid(
+            cfg, world_size=world_size, validate=args.validate)
     else:
-        train_model(cfg,
-                    weights=args.weights,
-                    parallel=parallel,
-                    validate=args.validate,
-                    use_fleet=args.fleet,
-                    use_amp=args.amp,
-                    amp_level=args.amp_level,
-                    max_iters=args.max_iters,
-                    profiler_options=args.profiler_options)
+        train_model(
+            cfg,
+            weights=args.weights,
+            parallel=parallel,
+            validate=args.validate,
+            use_fleet=args.fleet,
+            use_amp=args.amp,
+            amp_level=args.amp_level,
+            max_iters=args.max_iters,
+            profiler_options=args.profiler_options)
 
 
 if __name__ == '__main__':

--- a/paddlevideo/tasks/test.py
+++ b/paddlevideo/tasks/test.py
@@ -45,23 +45,26 @@ def test_model(cfg, weights, parallel=True):
     dataset = build_dataset((cfg.DATASET.test, cfg.PIPELINE.test))
     batch_size = cfg.DATASET.get("test_batch_size", 8)
 
-    if cfg.get('use_npu'):
+    if cfg.get('use_npu', False):
         places = paddle.set_device('npu')
+    elif cfg.get('use_xpu', False):
+        places = paddle.set_device('xpu')
     else:
         places = paddle.set_device('gpu')
 
     # default num worker: 0, which means no subprocess will be created
     num_workers = cfg.DATASET.get('num_workers', 0)
     num_workers = cfg.DATASET.get('test_num_workers', num_workers)
-    dataloader_setting = dict(batch_size=batch_size,
-                              num_workers=num_workers,
-                              places=places,
-                              drop_last=False,
-                              shuffle=False)
+    dataloader_setting = dict(
+        batch_size=batch_size,
+        num_workers=num_workers,
+        places=places,
+        drop_last=False,
+        shuffle=False)
 
     data_loader = build_dataloader(
-        dataset, **dataloader_setting) if cfg.model_name not in ['CFBI'
-                                                                 ] else dataset
+        dataset,
+        **dataloader_setting) if cfg.model_name not in ['CFBI'] else dataset
 
     model.eval()
 

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -363,9 +363,9 @@ else
                 if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_amp_config} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2} > ${LOG_PATH}/train.log 2>&1"
                 elif [ ${#ips} -le 15 ];then  # train with multi-gpu
-                    cmd="${python} -B -m paddle.distributed.launch --gpus=\"${gpu}\" ${run_train} ${set_amp_config} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2} > ${LOG_PATH}/train.log 2>&1"
+                    cmd="${python} -B -m paddle.distributed.launch --devices=\"${gpu}\" ${run_train} ${set_amp_config} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_train_params1} ${set_train_params2} > ${LOG_PATH}/train.log 2>&1"
                 else     # train with multi-machine
-                    cmd="${python} -B -m paddle.distributed.launch --ips=${ips} --gpus=\"${gpu}\" ${run_train} ${set_amp_config} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_batchsize} ${set_train_params1} ${set_train_params2} > ${LOG_PATH}/train.log 2>&1"
+                    cmd="${python} -B -m paddle.distributed.launch --ips=${ips} --devices=\"${gpu}\" ${run_train} ${set_amp_config} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_batchsize} ${set_train_params1} ${set_train_params2} > ${LOG_PATH}/train.log 2>&1"
                 fi
 
                 # run train

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e "print Cwd::abs_path shift" "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# disable mkldnn on non x86_64 env
+arch=$(uname -i)
+if [ $arch != "x86_64" ]; then
+    sed -i "s/--enable_mkldnn:True|False/--enable_mkldnn:False/g" $FILENAME
+    sed -i "s/--enable_mkldnn:True/--enable_mkldnn:False/g" $FILENAME
+fi
+
+# change gpu to npu in tipc txt configs
+sed -i "s/use_gpu/use_npu/g" $FILENAME
+# disable benchmark as AutoLog required nvidia-smi command
+sed -i "s/--enable_benchmark:True/--enable_benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to npu in execution script
+sed -i "s/\"gpu\"/\"npu\"/g" test_tipc/test_train_inference_python.sh
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo -e "\033[1;32m Started to run command: ${cmd}!  \033[0m"
+eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e "print Cwd::abs_path shift" "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# disable mkldnn on non x86_64 env
+arch=$(uname -i)
+if [ $arch != "x86_64" ]; then
+    sed -i "s/--enable_mkldnn:True|False/--enable_mkldnn:False/g" $FILENAME
+    sed -i "s/--enable_mkldnn:True/--enable_mkldnn:False/g" $FILENAME
+fi
+
+# change gpu to xpu in tipc txt configs
+sed -i "s/use_gpu/use_xpu/g" $FILENAME
+# disable benchmark as AutoLog required nvidia-smi command
+sed -i "s/--enable_benchmark:True/--enable_benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to xpu in execution script
+sed -i "s/\"gpu\"/\"xpu\"/g" test_tipc/test_train_inference_python.sh
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo -e "\033[1;32m Started to run command: ${cmd}!  \033[0m"
+eval $cmd

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -29,27 +29,32 @@ def parse_args():
 
     # general params
     parser = argparse.ArgumentParser("PaddleVideo Inference model script")
-    parser.add_argument('-c',
-                        '--config',
-                        type=str,
-                        default='configs/example.yaml',
-                        help='config file path')
-    parser.add_argument('-o',
-                        '--override',
-                        action='append',
-                        default=[],
-                        help='config options to be overridden')
+    parser.add_argument(
+        '-c',
+        '--config',
+        type=str,
+        default='configs/example.yaml',
+        help='config file path')
+    parser.add_argument(
+        '-o',
+        '--override',
+        action='append',
+        default=[],
+        help='config options to be overridden')
     parser.add_argument("-i", "--input_file", type=str, help="input file path")
-    parser.add_argument("--time_test_file",
-                        type=str2bool,
-                        default=False,
-                        help="whether input time test file")
+    parser.add_argument(
+        "--time_test_file",
+        type=str2bool,
+        default=False,
+        help="whether input time test file")
     parser.add_argument("--model_file", type=str)
     parser.add_argument("--params_file", type=str)
 
     # params for paddle predict
     parser.add_argument("-b", "--batch_size", type=int, default=1)
     parser.add_argument("--use_gpu", type=str2bool, default=True)
+    parser.add_argument("--use_xpu", type=str2bool, default=False)
+    parser.add_argument("--use_npu", type=str2bool, default=False)
     parser.add_argument("--precision", type=str, default="fp32")
     parser.add_argument("--ir_optim", type=str2bool, default=True)
     parser.add_argument("--use_tensorrt", type=str2bool, default=False)
@@ -67,6 +72,10 @@ def create_paddle_predictor(args, cfg):
     config = Config(args.model_file, args.params_file)
     if args.use_gpu:
         config.enable_use_gpu(args.gpu_mem, 0)
+    elif args.use_npu:
+        config.enable_npu()
+    elif args.use_xpu:
+        config.enable_xpu()
     else:
         config.disable_gpu()
         if args.cpu_threads:
@@ -110,8 +119,8 @@ def create_paddle_predictor(args, cfg):
             elif 'tokenshift' in cfg.model_name.lower():
                 num_views = 3  # UniformCrop
             max_batch_size = args.batch_size * num_views * num_seg * seg_len
-        config.enable_tensorrt_engine(precision_mode=precision,
-                                      max_batch_size=max_batch_size)
+        config.enable_tensorrt_engine(
+            precision_mode=precision, max_batch_size=max_batch_size)
 
     config.enable_memory_optim()
     # use zero copy
@@ -223,21 +232,20 @@ def main():
                       f"package and it's dependencies is required for "
                       f"python-inference when enable_benchmark=True.")
             pid = os.getpid()
-            autolog = auto_log.AutoLogger(model_name=cfg.model_name,
-                                          model_precision=args.precision,
-                                          batch_size=args.batch_size,
-                                          data_shape="dynamic",
-                                          save_path="./output/auto_log.lpg",
-                                          inference_config=inference_config,
-                                          pids=pid,
-                                          process_name=None,
-                                          gpu_ids=0 if args.use_gpu else None,
-                                          time_keys=[
-                                              'preprocess_time',
-                                              'inference_time',
-                                              'postprocess_time'
-                                          ],
-                                          warmup=num_warmup)
+            autolog = auto_log.AutoLogger(
+                model_name=cfg.model_name,
+                model_precision=args.precision,
+                batch_size=args.batch_size,
+                data_shape="dynamic",
+                save_path="./output/auto_log.lpg",
+                inference_config=inference_config,
+                pids=pid,
+                process_name=None,
+                gpu_ids=0 if args.use_gpu else None,
+                time_keys=[
+                    'preprocess_time', 'inference_time', 'postprocess_time'
+                ],
+                warmup=num_warmup)
             if not args.time_test_file:
                 test_video_num = 15
                 files = [args.input_file for _ in range(test_video_num)]


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本

```bash
# 准备小数据集
bash test_tipc/prepare.sh \
         test_tipc/configs/PP-TSM/train_infer_python.txt 'lite_train_lite_infer'

# GPU上运行单测模型，脚本保持不变
bash test_tipc/test_train_inference_python.sh \
         test_tipc/configs/PP-TSM/train_infer_python.txt 'lite_train_lite_infer'

# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh \
         test_tipc/configs/PP-TSM/train_infer_python.txt 'lite_train_lite_infer'

# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh \
         test_tipc/configs/PP-TSM/train_infer_python.txt 'lite_train_lite_infer'
```

昆仑上测试结果如下：
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/16605440/190176589-b75cdf86-bf57-461a-953a-e6b93f13bbfd.png">
