### PR TITLE
[TIPC]Add more dy2st model for tipc

### DIFF
--- a/test_tipc/configs/SlowFast/train_infer_python.txt
+++ b/test_tipc/configs/SlowFast/train_infer_python.txt
@@ -58,3 +58,5 @@ epoch:1
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_conv_workspace_size_limit=800
 max-iters:2000
+===========================to_static_train_benchmark_params===========================
+to_static_train:-o to_static=True

--- a/test_tipc/configs/TSM/train_infer_python.txt
+++ b/test_tipc/configs/TSM/train_infer_python.txt
@@ -58,3 +58,5 @@ epoch:1
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_conv_workspace_size_limit=800
 max-iters:100
+===========================to_static_train_benchmark_params===========================
+to_static_train:-o to_static=True

--- a/test_tipc/configs/TSN/train_infer_python.txt
+++ b/test_tipc/configs/TSN/train_infer_python.txt
@@ -58,3 +58,5 @@ epoch:1
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_conv_workspace_size_limit=800
 max-iters:100
+===========================to_static_train_benchmark_params===========================
+to_static_train:-o to_static=True


### PR DESCRIPTION
添加TSM、TSN、SlowFast3个模型6个配置动转静tipc监控，稳定性自测如下，因没有空闲的8卡机器所以8卡性能未测试
![image](https://user-images.githubusercontent.com/23097963/205589304-7a62175b-2841-4240-9cc6-56858593316f.png)
