### PR TITLE
[TIPC] Adjust the order of set_device

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,36 +24,35 @@ from paddlevideo.utils import get_config, get_dist_info
 
 def parse_args():
     parser = argparse.ArgumentParser("PaddleVideo train script")
-    parser.add_argument(
-        '-c',
-        '--config',
-        type=str,
-        default='configs/example.yaml',
-        help='config file path')
-    parser.add_argument(
-        '-o',
-        '--override',
-        action='append',
-        default=[],
-        help='config options to be overridden')
-    parser.add_argument(
-        '--test', action='store_true', help='whether to test a model')
-    parser.add_argument(
-        '--train_dali',
-        action='store_true',
-        help='whether to use dali to speed up training')
-    parser.add_argument(
-        '--multigrid',
-        action='store_true',
-        help='whether to use multigrid training')
-    parser.add_argument(
-        '-w', '--weights', type=str, help='weights for finetuning or testing')
-    parser.add_argument(
-        '--fleet',
-        action='store_true',
-        help='whether to use fleet run distributed training')
-    parser.add_argument(
-        '--amp', action='store_true', help='whether to open amp training.')
+    parser.add_argument('-c',
+                        '--config',
+                        type=str,
+                        default='configs/example.yaml',
+                        help='config file path')
+    parser.add_argument('-o',
+                        '--override',
+                        action='append',
+                        default=[],
+                        help='config options to be overridden')
+    parser.add_argument('--test',
+                        action='store_true',
+                        help='whether to test a model')
+    parser.add_argument('--train_dali',
+                        action='store_true',
+                        help='whether to use dali to speed up training')
+    parser.add_argument('--multigrid',
+                        action='store_true',
+                        help='whether to use multigrid training')
+    parser.add_argument('-w',
+                        '--weights',
+                        type=str,
+                        help='weights for finetuning or testing')
+    parser.add_argument('--fleet',
+                        action='store_true',
+                        help='whether to use fleet run distributed training')
+    parser.add_argument('--amp',
+                        action='store_true',
+                        help='whether to open amp training.')
     parser.add_argument(
         '--amp_level',
         type=str,
@@ -90,7 +89,8 @@ def main():
     cfg = get_config(args.config, overrides=args.override)
 
     # enable to use npu if paddle is built with npu
-    if paddle.device.is_compiled_with_npu():
+    if paddle.device.is_compiled_with_npu(
+    ) or "npu" in paddle.device.get_all_custom_device_type():
         cfg.__setattr__("use_npu", True)
     elif paddle.device.is_compiled_with_xpu():
         cfg.__setattr__("use_xpu", True)
@@ -123,19 +123,19 @@ def main():
     elif args.train_dali:
         train_dali(cfg, weights=args.weights, parallel=parallel)
     elif args.multigrid:
-        train_model_multigrid(
-            cfg, world_size=world_size, validate=args.validate)
+        train_model_multigrid(cfg,
+                              world_size=world_size,
+                              validate=args.validate)
     else:
-        train_model(
-            cfg,
-            weights=args.weights,
-            parallel=parallel,
-            validate=args.validate,
-            use_fleet=args.fleet,
-            use_amp=args.amp,
-            amp_level=args.amp_level,
-            max_iters=args.max_iters,
-            profiler_options=args.profiler_options)
+        train_model(cfg,
+                    weights=args.weights,
+                    parallel=parallel,
+                    validate=args.validate,
+                    use_fleet=args.fleet,
+                    use_amp=args.amp,
+                    amp_level=args.amp_level,
+                    max_iters=args.max_iters,
+                    profiler_options=args.profiler_options)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Adjust the order of set_device. The set_device function should be placed before build_dataset;
2. Add `"npu" in paddle.device.get_all_custom_device_type():` in main.py to support custom device.