### PR TITLE
Use `inspect.getfullargspec` instead of deprecated `inspect.getargspec`

### DIFF
--- a/paddlevideo/solver/optimizer.py
+++ b/paddlevideo/solver/optimizer.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 import inspect
-# for python3.11
-if not hasattr(inspect, 'getargspec'):
-    inspect.getargspec = inspect.getfullargspec
-
 from typing import Dict
 
 import paddle
@@ -124,7 +120,7 @@ def build_optimizer(cfg: Dict,
         'parameters': model.parameters(),
         **cfg_copy
     }
-    optimizer_init_args = inspect.getargspec(
+    optimizer_init_args = inspect.getfullargspec(
         getattr(paddle.optimizer, opt_name).__init__).args
     if use_amp and amp_level == "O2" and "multi_precision" in optimizer_init_args:
         # support "multi_precision" arg in optimizer's __init__ function.


### PR DESCRIPTION
<img width="931" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/38436475/312380a0-ec67-4a05-bd76-7717b3f8e8b8">

同 PaddlePaddle/PaddleClas#3168

PaddlePaddle/Paddle#65284 为 Momentum 优化器添加类型提示，PR-CI-Model-benchmark 挂在了这里